### PR TITLE
fix(ui): broken @rive-app/canvas dependencies when import outside from bundled packages

### DIFF
--- a/docs/.vitepress/theme/components/RiveCanvas.vue
+++ b/docs/.vitepress/theme/components/RiveCanvas.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vitepress'
-import type { Rive } from '@rive-app/canvas-lite'
+import * as Rive from '@rive-app/canvas'
 
 const route = useRoute()
-const riveInstances = ref<Rive[]>([])
+const riveInstances = ref<Rive.Rive[]>([])
 
 const defaultCreateCanvasOptions = {
   canvasWidth: 500,
@@ -126,8 +126,7 @@ async function renderRiveAsset() {
 
     el.appendChild(canvas)
 
-    const rive = await import('@rive-app/canvas-lite')
-    const r = new rive.Rive({
+    const r = new Rive.Rive({
       canvas,
       src: src.value,
       autoplay: true,

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,10 @@
 import { h } from 'vue'
 
 import { NolebasePluginSet, defineThemeUnconfig } from '@nolebase/unconfig-vitepress'
-import { NuLazyDOMRiveCanvas } from '@nolebase/ui'
 
 import IntegrationCard from './components/IntegrationCard.vue'
 import HomeContent from './components/HomeContent.vue'
+import RiveCanvas from './components/RiveCanvas.vue'
 
 import 'virtual:uno.css'
 
@@ -16,7 +16,7 @@ export default defineThemeUnconfig({
     slots: {
       'layout-top': {
         node: [
-          () => h(NuLazyDOMRiveCanvas),
+          () => h(RiveCanvas),
         ],
       },
     },

--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -118,8 +118,3 @@
   --vp-custom-block-tip-bg: #074364;
   --vp-custom-block-tip-code-bg: #0d171e9c;
 }
-
-:root {
-  --vp-nolebase-highlight-targeted-heading-color: var(--vp-custom-block-tip-text);
-  --vp-nolebase-highlight-targeted-heading-bg: rgba(253, 216, 95, 0.31);
-}

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "@nolebase/unconfig-vitepress": "workspace:^",
     "@nolebase/vitepress-plugin-git-changelog": "workspace:^",
     "@nolebase/vitepress-plugin-og-image": "workspace:^",
-    "@nolebase/vitepress-plugin-page-properties": "workspace:^"
+    "@nolebase/vitepress-plugin-page-properties": "workspace:^",
+    "@rive-app/canvas": "^2.11.1"
   }
 }

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -28,6 +28,11 @@ export default defineConfig({
   define: {
     __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: getVueProdHydrationMismatchDetailsFlag(),
   },
+  optimizeDeps: {
+    exclude: [
+      'vitepress',
+    ],
+  },
   resolve: {
     alias: {
       '@nolebase/ui': resolve(__dirname, '../packages/ui/src/'),
@@ -62,27 +67,17 @@ export default defineConfig({
 
         return 'Contributors'
       },
-      excludes: [],
-      exclude: (_, { helpers }): boolean => {
-        if (helpers.idEquals(join('pages', 'en', 'index.md')))
-          return true
-        if (helpers.idEquals(join('pages', 'zh-CN', 'index.md')))
-          return true
-
-        return false
-      },
+      excludes: [
+        join('pages', 'en', 'index.md'),
+        join('pages', 'zh-CN', 'index.md'),
+      ],
     }),
     PageProperties(),
     PagePropertiesMarkdownSection({
-      excludes: [],
-      exclude: (_, { helpers }): boolean => {
-        if (helpers.idEquals(join('pages', 'en', 'index.md')))
-          return true
-        if (helpers.idEquals(join('pages', 'zh-CN', 'index.md')))
-          return true
-
-        return false
-      },
+      excludes: [
+        join('pages', 'en', 'index.md'),
+        join('pages', 'zh-CN', 'index.md'),
+      ],
     }),
   ],
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nolebase/ui",
   "type": "module",
-  "version": "1.25.2",
+  "version": "1.25.12",
   "description": "A collection of Vue components Nolebase uses.",
   "author": {
     "name": "Nólëbase",
@@ -66,11 +66,7 @@
     "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
   },
   "peerDependencies": {
-    "@rive-app/canvas-lite": "^2.10.0",
     "vue": "^3.2.0"
-  },
-  "dependencies": {
-    "@rive-app/canvas-lite": "^2.10.3"
   },
   "devDependencies": {
     "@vue/tsconfig": "^0.5.1"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,19 +1,15 @@
 import type { App } from 'vue'
 
 import NuButton from './components/NuButton.vue'
-import NuLazyDOMRiveCanvas from './components/NuLazyDOMRiveCanvas.vue'
 import NuVerticalTransition from './components/NuVerticalTransition.vue'
 
 export {
   NuButton,
-  NuLazyDOMRiveCanvas,
   NuVerticalTransition,
 }
 
 export function install(app: App): void {
   app.component('NuButton', NuButton)
-
   // Animations
-  app.component('NuLazyDOMRiveCanvas', NuLazyDOMRiveCanvas)
   app.component('NuVerticalTransition', NuVerticalTransition)
 }

--- a/packages/vitepress-plugin-git-changelog/src/vite/markdownSection.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/markdownSection.ts
@@ -147,7 +147,7 @@ export function GitChangelogMarkdownSection(options?: GitChangelogMarkdownSectio
 
       if (!id.endsWith('.md'))
         return null
-      if (excludes.includes(id))
+      if (excludes.includes(relative(root, id)))
         return null
       if (exclude(id, { helpers: { pathStartsWith, pathEquals, pathEndsWith, idEndsWith, idEquals, idStartsWith } }))
         return null

--- a/packages/vitepress-plugin-page-properties/src/vite/markdownSection.ts
+++ b/packages/vitepress-plugin-page-properties/src/vite/markdownSection.ts
@@ -123,7 +123,7 @@ export function PagePropertiesMarkdownSection(options?: PagePropertiesMarkdownSe
 
       if (!id.endsWith('.md'))
         return null
-      if (excludes.includes(id))
+      if (excludes.includes(relative(root, id)))
         return null
       if (exclude(id, context))
         return null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@nolebase/vitepress-plugin-page-properties':
         specifier: workspace:^
         version: link:../packages/vitepress-plugin-page-properties
+      '@rive-app/canvas':
+        specifier: ^2.11.1
+        version: 2.11.1
 
   packages/markdown-it-bi-directional-links:
     dependencies:
@@ -129,9 +132,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@rive-app/canvas-lite':
-        specifier: ^2.10.3
-        version: 2.10.3
       vue:
         specifier: ^3.2.0
         version: 3.4.19(typescript@5.4.2)
@@ -1428,9 +1428,9 @@ packages:
       '@resvg/resvg-js-win32-x64-msvc': 2.6.0
     dev: false
 
-  /@rive-app/canvas-lite@2.10.3:
-    resolution: {integrity: sha512-AJyNwZ/KfWckvRWryJlviGlIxGcy7mW7UPk0NUSCIp1JtOzBH7eECrh+4Chw3NV8piAhSIhItsIGrsejODE/Cw==}
-    dev: false
+  /@rive-app/canvas@2.11.1:
+    resolution: {integrity: sha512-3+fqf1Lo2T0BhY+TKtAp4wquhnC6dpnMgmI5efrN7FjJm5115TbkDpqzfZqrZkSxhT7v5C8jUI4aRPmkCj9kSA==}
+    dev: true
 
   /@rollup/plugin-alias@5.1.0(rollup@3.29.4):
     resolution: {integrity: sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==}


### PR DESCRIPTION
Follow up #124 and #127 .

Temporarily removed `RiveCanvas` components for #91 that required by #94 out back to `integrations-docs` package as direct imported dependencies while waiting for feedbacks and confirmation of fixes by developers of @rive-app.