### PR TITLE
fix(ui|git-changelog): missing configurations for @rive-app/canvas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,8 @@
     "Rehype",
     "resvg",
     "unconfig",
-    "uncrypto"
+    "uncrypto",
+    "Nisekoi5"
   ],
   "prettier.enable": false,
   "editor.formatOnSave": false,

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,10 @@
 import { h } from 'vue'
 
+import { NuLazyTeleportRiveCanvas } from '@nolebase/ui'
 import { NolebasePluginSet, defineThemeUnconfig } from '@nolebase/unconfig-vitepress'
 
 import IntegrationCard from './components/IntegrationCard.vue'
 import HomeContent from './components/HomeContent.vue'
-import RiveCanvas from './components/RiveCanvas.vue'
 
 import 'virtual:uno.css'
 
@@ -16,7 +16,7 @@ export default defineThemeUnconfig({
     slots: {
       'layout-top': {
         node: [
-          () => h(RiveCanvas),
+          () => h(NuLazyTeleportRiveCanvas),
         ],
       },
     },

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,75 @@
+# `@nolebase/ui`
+
+A collection of Vue components Nolebase uses.
+
+> [!CAUTION] This package is in Alpha stage
+>
+> This package is still in the Alpha stage, and it is not recommended to use it in production. The API may change in the future, and there may be bugs in the current version. Please use it with caution.
+
+> [!IMPORTANT] Before install
+>
+> Currently `@nolebase/ui` is still under development, and will be used by other [Nolebase Integrations](https://nolebase-integrations.ayaka.io) components now. There are a few configurations that needed to be configured if you would ever want to install `@nolebase/ui` as one of your dependencies:
+>
+> ### 1. Additional configurations for Vite
+>
+> #### 1.1 For users who imported `<NuLazyTeleportRiveCanvas />` component
+>
+> Since `<NuLazyTeleportRiveCanvas />` depends on `@rive-app/canvas`. If you also use Vite as your bundler, you will need to add the following configurations to your `vite.config.ts` file like this:
+>
+> ```typescript
+> export default defineConfig(() => {
+>   return {
+>     optimizeDeps: {
+>       include: [
+>         // Add this line to your vite.config.ts
+>         '@nolebase/ui > @rive-app/canvas',
+>       ],
+>     },
+>   }
+> })
+> ```
+>
+> For more information about why configure this, please refer to the [Dep Optimization Options | Vite](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-exclude) documentation.
+>
+> #### 1.2 For users who imported VitePress related components
+>
+> If you are using VitePress, you will need to add the following configurations to your `vite.config.ts` file like this:
+>
+> ```typescript
+> export default defineConfig(() => {
+>   return {
+>     ssr: {
+>       noExternal: [
+>         // Add this line to your vite.config.ts
+>         '@nolebase/ui',
+>       ],
+>     },
+>   }
+> })
+> ```
+>
+> For more information about why configure this, please refer to the [Server-Side Rendering | Vite](https://vitejs.dev/guide/ssr.html#ssr-externals) documentation.
+
+## Install
+
+### Npm
+
+```shell
+npm i @nolebase/ui -D
+```
+
+### Yarn
+
+```shell
+yarn add @nolebase/ui -D
+```
+
+### Pnpm
+
+```shell
+pnpm add @nolebase/ui -D
+```
+
+## Documentation
+
+Please refer to [UI Components](https://nolebase-integrations.ayaka.io/pages/en/ui/) for more information.

--- a/packages/ui/build.config.ts
+++ b/packages/ui/build.config.ts
@@ -29,4 +29,8 @@ export default defineBuildConfig({
   ],
   declaration: true,
   clean: true,
+  externals: [
+    '@rive-app/canvas',
+    'vue',
+  ],
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nolebase/ui",
   "type": "module",
-  "version": "1.25.12",
+  "version": "1.25.2",
   "description": "A collection of Vue components Nolebase uses.",
   "author": {
     "name": "Nólëbase",
@@ -67,6 +67,9 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0"
+  },
+  "dependencies": {
+    "@rive-app/canvas": "^2.11.1"
   },
   "devDependencies": {
     "@vue/tsconfig": "^0.5.1"

--- a/packages/ui/src/components/NuLazyTeleportRiveCanvas.vue
+++ b/packages/ui/src/components/NuLazyTeleportRiveCanvas.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vitepress'
-import * as Rive from '@rive-app/canvas'
+import type { Rive } from '@rive-app/canvas'
 
 const route = useRoute()
-const riveInstances = ref<Rive.Rive[]>([])
+const riveInstances = ref<Rive[]>([])
 
 const defaultCreateCanvasOptions = {
   canvasWidth: 500,
@@ -126,7 +126,8 @@ async function renderRiveAsset() {
 
     el.appendChild(canvas)
 
-    const r = new Rive.Rive({
+    const rive = await import('@rive-app/canvas')
+    const r = new rive.Rive({
       canvas,
       src: src.value,
       autoplay: true,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,14 +2,17 @@ import type { App } from 'vue'
 
 import NuButton from './components/NuButton.vue'
 import NuVerticalTransition from './components/NuVerticalTransition.vue'
+import NuLazyTeleportRiveCanvas from './components/NuLazyTeleportRiveCanvas.vue'
 
 export {
   NuButton,
   NuVerticalTransition,
+  NuLazyTeleportRiveCanvas,
 }
 
 export function install(app: App): void {
   app.component('NuButton', NuButton)
   // Animations
+  app.component('NuLazyTeleportRiveCanvas', NuLazyTeleportRiveCanvas)
   app.component('NuVerticalTransition', NuVerticalTransition)
 }

--- a/packages/vitepress-plugin-git-changelog/src/vite/git.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/git.ts
@@ -163,6 +163,11 @@ export function GitChangelog(options: {
     name: '@nolebase/vitepress-plugin-git-changelog',
     config: () => ({
       optimizeDeps: {
+        include: [
+          // @rive-app/canvas is a CJS/UMD module, so it needs to be included here
+          // for Vite to properly bundle it.
+          '@nolebase/vitepress-plugin-git-changelog > @nolebase/ui > @rive-app/canvas',
+        ],
         exclude: [
           '@nolebase/vitepress-plugin-git-changelog/client',
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 2.0.0(typescript@5.4.2)
       unocss:
         specifier: ^0.57.7
-        version: 0.57.7(postcss@8.4.35)(rollup@3.29.4)(vite@5.1.6)
+        version: 0.57.7(postcss@8.4.38)(rollup@3.29.4)(vite@5.1.6)
       unplugin-vue-macros:
         specifier: ^2.7.10
         version: 2.7.10(@vueuse/core@10.9.0)(rollup@3.29.4)(typescript@5.4.2)(vite@5.1.6)(vue@3.4.19)
@@ -73,7 +73,7 @@ importers:
         version: 0.8.3(rollup@3.29.4)(vite@5.1.6)
       vitepress:
         specifier: ^1.0.0-rc.45
-        version: 1.0.0-rc.45(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.45(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
       vue:
         specifier: 3.4.19
         version: 3.4.19(typescript@5.4.2)
@@ -135,6 +135,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@rive-app/canvas':
+        specifier: ^2.11.1
+        version: 2.11.1
       vue:
         specifier: ^3.2.0
         version: 3.4.19(typescript@5.4.2)
@@ -162,7 +165,7 @@ importers:
         version: link:../vitepress-plugin-page-properties
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.45(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.45(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
     devDependencies:
       builtin-modules:
         specifier: ^3.3.0
@@ -172,7 +175,7 @@ importers:
     dependencies:
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
 
   packages/vitepress-plugin-git-changelog:
     dependencies:
@@ -199,7 +202,7 @@ importers:
         version: 0.1.3
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
     devDependencies:
       builtin-modules:
         specifier: ^3.3.0
@@ -209,13 +212,13 @@ importers:
     dependencies:
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
 
   packages/vitepress-plugin-inline-link-preview:
     dependencies:
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
 
   packages/vitepress-plugin-og-image:
     dependencies:
@@ -257,7 +260,7 @@ importers:
         version: 11.0.4
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.45(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.45(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -276,7 +279,7 @@ importers:
         version: 9.0.1
       vitepress:
         specifier: '>=1.0.0-rc.44'
-        version: 1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2)
+        version: 1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2)
     devDependencies:
       '@types/markdown-it':
         specifier: ^13.0.7
@@ -298,44 +301,44 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)(search-insights@2.13.0):
+  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)(search-insights@2.13.0):
     resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)(search-insights@2.13.0)
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)(search-insights@2.13.0)
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
       - search-insights
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)(search-insights@2.13.0):
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)(search-insights@2.13.0):
     resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
     peerDependencies:
       search-insights: '>= 1 < 3'
     dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)
       search-insights: 2.13.0
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
 
-  /@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1):
+  /@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1):
     resolution: {integrity: sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)
-      '@algolia/client-search': 4.22.1
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)
+      '@algolia/client-search': 4.23.1
       algoliasearch: 4.22.1
 
-  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1):
+  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1):
     resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/client-search': 4.22.1
+      '@algolia/client-search': 4.23.1
       algoliasearch: 4.22.1
 
   /@algolia/cache-browser-local-storage@4.22.1:
@@ -345,6 +348,9 @@ packages:
 
   /@algolia/cache-common@4.22.1:
     resolution: {integrity: sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA==}
+
+  /@algolia/cache-common@4.23.1:
+    resolution: {integrity: sha512-w0sqXuwbGyIDsFDHTZzTv79rZjW7vc/6vCPdqYAAkiUlvvCdUo0cCWFXpbMpvYHBS2IXZXJaQY0R9yL/bmk9VQ==}
 
   /@algolia/cache-in-memory@4.22.1:
     resolution: {integrity: sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==}
@@ -372,6 +378,12 @@ packages:
       '@algolia/requester-common': 4.22.1
       '@algolia/transporter': 4.22.1
 
+  /@algolia/client-common@4.23.1:
+    resolution: {integrity: sha512-01lBsO8r4KeXWIDzVQoPMYwOndeAvSQk3xk3Bxwrt2ag5jrGswiq8DgEqPVx+PQw+7T5GY6dS25cYcdv1dVorA==}
+    dependencies:
+      '@algolia/requester-common': 4.23.1
+      '@algolia/transporter': 4.23.1
+
   /@algolia/client-personalization@4.22.1:
     resolution: {integrity: sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==}
     dependencies:
@@ -386,8 +398,18 @@ packages:
       '@algolia/requester-common': 4.22.1
       '@algolia/transporter': 4.22.1
 
+  /@algolia/client-search@4.23.1:
+    resolution: {integrity: sha512-jeA1ZksO0N33SZhcLRa4paUI7LFJrrhtMlw27eIdPTVv/npV0dMLoNGPg3MuLSeZqRKqfpY7tTOBjRZFMhskLg==}
+    dependencies:
+      '@algolia/client-common': 4.23.1
+      '@algolia/requester-common': 4.23.1
+      '@algolia/transporter': 4.23.1
+
   /@algolia/logger-common@4.22.1:
     resolution: {integrity: sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg==}
+
+  /@algolia/logger-common@4.23.1:
+    resolution: {integrity: sha512-hGsqJrpeZfw1Ng8ctWj9gg8zXlSmEMA0cfbBn3yoZa3so8oQZmB9uz57AJcJj1CfSBf+5SK8/AF4kjTungvgUA==}
 
   /@algolia/logger-console@4.22.1:
     resolution: {integrity: sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==}
@@ -402,6 +424,9 @@ packages:
   /@algolia/requester-common@4.22.1:
     resolution: {integrity: sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg==}
 
+  /@algolia/requester-common@4.23.1:
+    resolution: {integrity: sha512-G9+ySLxPBtn2o6Mk4NoxPnkYtAe/isxrVy5LmJ4za+aYEdV5tvZpgvn+k4558T7XoRBrI2eQKyjnvQs7zJeCdw==}
+
   /@algolia/requester-node-http@4.22.1:
     resolution: {integrity: sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==}
     dependencies:
@@ -413,6 +438,13 @@ packages:
       '@algolia/cache-common': 4.22.1
       '@algolia/logger-common': 4.22.1
       '@algolia/requester-common': 4.22.1
+
+  /@algolia/transporter@4.23.1:
+    resolution: {integrity: sha512-8ucVx0hV7yIeTZUFsix31UEIJFRauPriWlzLBbDy9gRHrK45WbMQ1S9FliDdoY5OvbFxi0/5OKRj0Dw1EkbcJA==}
+    dependencies:
+      '@algolia/cache-common': 4.23.1
+      '@algolia/logger-common': 4.23.1
+      '@algolia/requester-common': 4.23.1
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -544,6 +576,16 @@ packages:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
     dev: true
+
+  /@babel/code-frame@7.24.2:
+    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/highlight': 7.24.2
+      picocolors: 1.0.0
+    dev: true
+    optional: true
 
   /@babel/compat-data@7.23.5:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
@@ -716,6 +758,11 @@ packages:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.24.1:
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -746,12 +793,32 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@babel/highlight@7.24.2:
+    resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
+    engines: {node: '>=6.9.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+    dev: true
+    optional: true
+
   /@babel/parser@7.23.9:
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.23.9
+
+  /@babel/parser@7.24.1:
+    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -859,6 +926,15 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
+  /@babel/types@7.24.0:
+    resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
+
   /@clack/core@0.3.4:
     resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
     dependencies:
@@ -879,10 +955,10 @@ packages:
   /@docsearch/css@3.5.2:
     resolution: {integrity: sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==}
 
-  /@docsearch/js@3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0):
+  /@docsearch/js@3.5.2(@algolia/client-search@4.23.1)(search-insights@2.13.0):
     resolution: {integrity: sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==}
     dependencies:
-      '@docsearch/react': 3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0)
+      '@docsearch/react': 3.5.2(@algolia/client-search@4.23.1)(search-insights@2.13.0)
       preact: 10.19.4
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -891,7 +967,7 @@ packages:
       - react-dom
       - search-insights
 
-  /@docsearch/react@3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0):
+  /@docsearch/react@3.5.2(@algolia/client-search@4.23.1)(search-insights@2.13.0):
     resolution: {integrity: sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -908,8 +984,8 @@ packages:
       search-insights:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)(search-insights@2.13.0)
-      '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.22.1)(algoliasearch@4.22.1)
+      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)(search-insights@2.13.0)
+      '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.23.1)(algoliasearch@4.22.1)
       '@docsearch/css': 3.5.2
       algoliasearch: 4.22.1
       search-insights: 2.13.0
@@ -1434,7 +1510,6 @@ packages:
 
   /@rive-app/canvas@2.11.1:
     resolution: {integrity: sha512-3+fqf1Lo2T0BhY+TKtAp4wquhnC6dpnMgmI5efrN7FjJm5115TbkDpqzfZqrZkSxhT7v5C8jUI4aRPmkCj9kSA==}
-    dev: true
 
   /@rollup/plugin-alias@5.1.0(rollup@3.29.4):
     resolution: {integrity: sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==}
@@ -2153,7 +2228,7 @@ packages:
       sirv: 2.0.4
     dev: true
 
-  /@unocss/postcss@0.57.7(postcss@8.4.35):
+  /@unocss/postcss@0.57.7(postcss@8.4.38):
     resolution: {integrity: sha512-13c9p5ecTvYa6inDky++8dlVuxQ0JuKaKW5A0NW3XuJ3Uz1t8Pguji+NAUddfTYEFF6GHu47L3Aac7vpI8pMcQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2165,7 +2240,7 @@ packages:
       css-tree: 2.3.1
       fast-glob: 3.3.2
       magic-string: 0.30.7
-      postcss: 8.4.35
+      postcss: 8.4.38
     dev: true
 
   /@unocss/preset-attributify@0.57.7:
@@ -2684,11 +2759,11 @@ packages:
   /@vue/compiler-core@3.4.21:
     resolution: {integrity: sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==}
     dependencies:
-      '@babel/parser': 7.23.9
+      '@babel/parser': 7.24.1
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: true
 
   /@vue/compiler-dom@3.4.19:
@@ -2720,15 +2795,15 @@ packages:
   /@vue/compiler-sfc@3.4.21:
     resolution: {integrity: sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==}
     dependencies:
-      '@babel/parser': 7.23.9
+      '@babel/parser': 7.24.1
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
       estree-walker: 2.0.2
       magic-string: 0.30.8
-      postcss: 8.4.35
-      source-map-js: 1.0.2
+      postcss: 8.4.38
+      source-map-js: 1.2.0
     dev: true
 
   /@vue/compiler-ssr@3.4.19:
@@ -5906,6 +5981,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss@8.4.38:
+    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.2.0
+
   /preact@10.19.4:
     resolution: {integrity: sha512-dwaX5jAh0Ga8uENBX1hSOujmKWgx9RtL80KaKUFLc6jb4vCEAc3EeZ0rnQO/FO4VgjfPMfoLFWnNG8bHuZ9VLw==}
 
@@ -6084,7 +6167,7 @@ packages:
       rollup: 3.29.4
       typescript: 5.4.2
     optionalDependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.2
     dev: true
 
   /rollup@3.29.4:
@@ -6237,6 +6320,10 @@ packages:
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
   /source-map@0.6.1:
@@ -6637,7 +6724,7 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  /unocss@0.57.7(postcss@8.4.35)(rollup@3.29.4)(vite@5.1.6):
+  /unocss@0.57.7(postcss@8.4.38)(rollup@3.29.4)(vite@5.1.6):
     resolution: {integrity: sha512-Z99ZZPkbkjIUXEM7L+K/7Y5V5yqUS0VigG7ZIFzLf/npieKmXHKlrPyvQWFQaf3OqooMFuKBQivh75TwvSOkcQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6653,7 +6740,7 @@ packages:
       '@unocss/cli': 0.57.7(rollup@3.29.4)
       '@unocss/core': 0.57.7
       '@unocss/extractor-arbitrary-variants': 0.57.7
-      '@unocss/postcss': 0.57.7(postcss@8.4.35)
+      '@unocss/postcss': 0.57.7(postcss@8.4.38)
       '@unocss/preset-attributify': 0.57.7
       '@unocss/preset-icons': 0.57.7
       '@unocss/preset-mini': 0.57.7
@@ -6896,7 +6983,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitepress@1.0.0-rc.44(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2):
+  /vitepress@1.0.0-rc.44(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2):
     resolution: {integrity: sha512-tO5taxGI7fSpBK1D8zrZTyJJERlyU9nnt0jHSt3fywfq3VKn977Hg0wUuTkEmwXlFYwuW26+6+3xorf4nD3XvA==}
     hasBin: true
     peerDependencies:
@@ -6909,7 +6996,7 @@ packages:
         optional: true
     dependencies:
       '@docsearch/css': 3.5.2
-      '@docsearch/js': 3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0)
+      '@docsearch/js': 3.5.2(@algolia/client-search@4.23.1)(search-insights@2.13.0)
       '@shikijs/core': 1.1.7
       '@shikijs/transformers': 1.1.7
       '@types/markdown-it': 13.0.7
@@ -6920,7 +7007,7 @@ packages:
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
-      postcss: 8.4.35
+      postcss: 8.4.38
       shiki: 1.1.7
       vite: 5.1.6(@types/node@20.11.28)(less@4.2.0)
       vue: 3.4.19(typescript@5.4.2)
@@ -6952,7 +7039,7 @@ packages:
       - universal-cookie
     dev: false
 
-  /vitepress@1.0.0-rc.45(@algolia/client-search@4.22.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.35)(search-insights@2.13.0)(typescript@5.4.2):
+  /vitepress@1.0.0-rc.45(@algolia/client-search@4.23.1)(@types/node@20.11.28)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.2):
     resolution: {integrity: sha512-/OiYsu5UKpQKA2c0BAZkfyywjfauDjvXyv6Mo4Ra57m5n4Bxg1HgUGoth1CLH2vwUbR/BHvDA9zOM0RDvgeSVQ==}
     hasBin: true
     peerDependencies:
@@ -6965,7 +7052,7 @@ packages:
         optional: true
     dependencies:
       '@docsearch/css': 3.5.2
-      '@docsearch/js': 3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0)
+      '@docsearch/js': 3.5.2(@algolia/client-search@4.23.1)(search-insights@2.13.0)
       '@shikijs/core': 1.1.7
       '@shikijs/transformers': 1.1.7
       '@types/markdown-it': 13.0.7
@@ -6976,7 +7063,7 @@ packages:
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
-      postcss: 8.4.35
+      postcss: 8.4.38
       shiki: 1.1.7
       vite: 5.1.6(@types/node@20.11.28)(less@4.2.0)
       vue: 3.4.19(typescript@5.4.2)


### PR DESCRIPTION
## Summaries and troubleshooting steps

When I was working on #124, I found out that the `@rive-app/canvas` break the other components then came up the temporarily fix at #128. However, the issue didn't went off, after fixing issues with `fast-glob`, I noticed that the CJS / UMD limitations for `@rive-app/canvas` where I may have a solution to fix.

According to `@rive-app/canvas`'s [documentation](https://help.rive.app/runtimes/overview/web-js#id-1.-install-the-dependency), developers should use the package like this:

```js
import * as rive from '@rive-app/canvas'
```

However, the error will appear as follow or either as what users had described in #124:

```
 Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'rive')
    at webpackUniversalModuleDefinition (universalModuleDefinition:9:1)
    at universalModuleDefinition:10:2
```

This seems weird for me, because `@rive-app/canvas` didn't cause any problems at the very first time I introduce it into Nolebase Integration, it worked really well. The error / issue would only appear when importing as dependency of dependency (for example wrapped the `@rive-app/canvas` into a component and then install the component into other packages or projects).

I went to search for some advices and suggestions about how the similar issue could get resolved:

- [[SSR] window is undefined · Issue #45 · rive-app/rive-wasm](https://github.com/rive-app/rive-wasm/issues/45)
- [Vite: "Uncaught TypeError: Cannot read properties of undefined (reading 'Rive')" · Issue #342 · rive-app/rive-wasm](https://github.com/rive-app/rive-wasm/issues/342)

After reading those issues, I noticed that the API / export mode has changed to named exports:

```js
import { Rive } from '@rive-app/canvas'
```

I tried to use the named exports. But error remained:

```
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/@rive-app+canvas@2.11.1/node_modules/@rive-app/canvas/rive.js?v=85efb5f9' does not provide an export named 'Rive' (at MyWrappedRiveCanvas.vue:4:10)
```

It may even produce errors like this when building:

```
Named export 'Rive' not found. The requested module '@rive-app/canvas' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@rive-app/canvas';
const { Rive } = pkg;
```

I thought there may be a delay of the changes to package, I switch back to `default` exports:

```js
import Rive from '@rive-app/canvas'
```

The error / issue remained still! And even changed every time I change the solution to import it:

```
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/@rive-app+canvas@2.11.1/node_modules/@rive-app/canvas/rive.js?v=1bcc8ace' does not provide an export named 'default'
```

At this time, I carefully opened the `node_modules` to find out why, and saw that the `@rive-app/canvas` contains no ESM module as exports, with a `.d.mjs` as definiations.

<img width="403" alt="image" src="https://github.com/rive-app/rive-wasm/assets/11081491/720ee2e5-a080-4baf-b79d-93cd9613a30f">

Until now, I still didn't realize what caused the issue, I thought there might be an issue about SSR, so I changed to dynamic import:

```js
const rive = await import('@rive-app/canvas')
```

But the issue still remained:

```
 Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'rive')
    at webpackUniversalModuleDefinition (universalModuleDefinition:9:1)
    at universalModuleDefinition:10:2
```

I went to check the code that throwed the error:

```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["rive"] = factory();
	else
		root["rive"] = factory();
})
```

and added breakpoints to inspect the scoped values, found that the `root` itself is truely undefined:

<img width="1352" alt="image" src="https://github.com/rive-app/rive-wasm/assets/11081491/b0eecda6-31e3-4dbd-93bf-671555c10a18">

From this time, I realized that might be issues about interpolation with `esbuild` that used by Vite:

- [Can't use webpackUniversalModuleDefinition in worker · Issue #2350 · vitejs/vite](https://github.com/vitejs/vite/issues/2350)
- [Unable to import UMD library · Issue #14605 · vitejs/vite](https://github.com/vitejs/vite/issues/14605)
- [javascript - Unable to import webpack-bundled UMD library as an ES6 import - Stack Overflow](https://stackoverflow.com/questions/54818030/unable-to-import-webpack-bundled-umd-library-as-an-es6-import)
- [javascript - Every imported function comes up as "undefined", though the import is clearly being made - Stack Overflow](https://stackoverflow.com/questions/62805412/every-imported-function-comes-up-as-undefined-though-the-import-is-clearly-be)

I went to search again to find out more, and finally understand the limitations, scope difference between UMD and ESM. I tried to override the `this` to `typeof window !== "undefined" ? window : this`:

```diff
console.log('rive this:', this);
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["rive"] = factory();
	else
		root["rive"] = factory();
--})(this, () => {
++})(typeof window !== "undefined" ? window : this, () => {
```

Then the imported module became this:

```
Module {Symbol(Symbol.toStringTag): 'Module'}
```

<img width="634" alt="image" src="https://github.com/rive-app/rive-wasm/assets/11081491/187a4c1a-680e-46fe-afc0-17ddc55cada6">

At the end, I went to read how the CJS interpolation works for [Dep Optimization Options | Vite](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-include), eventually understood the needed and requirements for nested CJS modules:

```typescript
export default defineConfig({
  optimizeDeps: {
    include: ['esm-dep > cjs-dep'],
  },
})
```