### PR TITLE
fix(ui): incorrect style exports

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@shikijs/vitepress-twoslash": "^1.2.4",
     "@types/markdown-it": "^13.0.7",
     "@types/markdown-it-footnote": "^3.0.4",
+    "asciinema-player": "^3.7.1",
     "colorette": "^2.0.20",
     "markdown-it": "^13.0.2",
     "markdown-it-footnote": "^4.0.0",

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -15,6 +15,30 @@ import { NuAsciinemaPlayer } from '@nolebase/ui'
   :loop="true"
 />
 
+## Installation
+
+Install `@nolebase/ui` and `asciinema-player` to your project dependencies by running the following command:
+
+::: code-group
+
+```shell [@antfu/ni]
+ni @nolebase/ui asciinema-player
+```
+
+```shell [pnpm]
+pnpm add @nolebase/ui asciinema-player
+```
+
+```shell [npm]
+npm install @nolebase/ui asciinema-player
+```
+
+```shell [yarn]
+yarn add @nolebase/ui asciinema-player
+```
+
+:::
+
 ```vue
 <script setup>
 import { NuAsciinemaPlayer } from '@nolebase/ui'

--- a/docs/pages/en/ui/lazy-teleport-rive-canvas/index.md
+++ b/docs/pages/en/ui/lazy-teleport-rive-canvas/index.md
@@ -29,6 +29,30 @@ Rive Canvas is a very special component. Unlike regular components, regular comp
   </div>
 </div>
 
+## Installation
+
+Install `@nolebase/ui` and `@rive-app/canvas` to your project dependencies by running the following command:
+
+::: code-group
+
+```shell [@antfu/ni]
+ni @nolebase/ui @rive-app/canvas
+```
+
+```shell [pnpm]
+pnpm add @nolebase/ui @rive-app/canvas
+```
+
+```shell [npm]
+npm install @nolebase/ui @rive-app/canvas
+```
+
+```shell [yarn]
+yarn add @nolebase/ui @rive-app/canvas
+```
+
+:::
+
 ## Usage
 
 ### Register as a global component

--- a/docs/pages/zh-CN/ui/asciinema-player/index.md
+++ b/docs/pages/zh-CN/ui/asciinema-player/index.md
@@ -15,6 +15,30 @@ import { NuAsciinemaPlayer } from '@nolebase/ui'
   :loop="true"
 />
 
+## 安装
+
+运行以下命令，将 `@nolebase/ui` 和 `asciinema-player` 安装到项目依赖项中：
+
+::: code-group
+
+```shell [@antfu/ni]
+ni @nolebase/ui asciinema-player
+```
+
+```shell [pnpm]
+pnpm add @nolebase/ui asciinema-player
+```
+
+```shell [npm]
+npm install @nolebase/ui asciinema-player
+```
+
+```shell [yarn]
+yarn add @nolebase/ui asciinema-player
+```
+
+:::
+
 ```vue
 <script setup>
 import { NuAsciinemaPlayer } from '@nolebase/ui'

--- a/docs/pages/zh-CN/ui/lazy-teleport-rive-canvas/index.md
+++ b/docs/pages/zh-CN/ui/lazy-teleport-rive-canvas/index.md
@@ -29,6 +29,30 @@ Rive Canvas（懒 Teleport）是一种极为特殊的组件，和常规的组件
   </div>
 </div>
 
+## 安装
+
+运行以下命令，将 `@nolebase/ui` 和 `@rive-app/canvas` 安装到项目依赖项中：
+
+::: code-group
+
+```shell [@antfu/ni]
+ni @nolebase/ui @rive-app/canvas
+```
+
+```shell [pnpm]
+pnpm add @nolebase/ui @rive-app/canvas
+```
+
+```shell [npm]
+npm install @nolebase/ui @rive-app/canvas
+```
+
+```shell [yarn]
+yarn add @nolebase/ui @rive-app/canvas
+```
+
+:::
+
 ## 用法
 
 ### 注册为全局组件

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -148,7 +148,7 @@ export default defineConfig({
     },
   },
   plugins: [
-    OmitReplacing('@nolebase/ui/client/style.css', resolve(__dirname, '../packages/ui/dist/client/style.css')),
+    OmitReplacing('@nolebase/ui/style.css', resolve(__dirname, '../packages/ui/dist/style.css')),
     Yaml() as Plugin,
     GitChangelog({
       maxGitLogCount: 2000,

--- a/packages/ui/build.config.ts
+++ b/packages/ui/build.config.ts
@@ -50,7 +50,7 @@ export default defineBuildConfig({
       //
       // The use of CLI was suggested by how to use unocss with rollup? · unocss/unocss · Discussion #542
       // https:// github.com/unocss/unocss/discussions/542
-      await execAsync('unocss "./src/client/**/*.vue" -o dist/client/style.css')
+      await execAsync('unocss "./src/**/*.vue" -o dist/style.css')
     },
   },
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./style.css": "./dist/style.css",
     "./*": {
       "types": "./dist/*",
       "import": "./dist/*.mjs",
@@ -66,17 +67,24 @@
     "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
   },
   "peerDependencies": {
+    "@rive-app/canvas": "^2.11.1",
+    "asciinema-player": "^3.7.1",
     "vitepress": "^1.0.0",
     "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {
+    "@rive-app/canvas": {
+      "optional": true
+    },
+    "asciinema-player": {
+      "optional": true
+    },
     "vitepress": {
       "optional": true
     }
   },
   "dependencies": {
-    "@rive-app/canvas": "^2.11.1",
-    "asciinema-player": "^3.7.1",
+    "@iconify-json/octicon": "^1.1.53",
     "less": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/vitepress-plugin-enhanced-readabilities/package.json
+++ b/packages/vitepress-plugin-enhanced-readabilities/package.json
@@ -26,6 +26,11 @@
   ],
   "sideEffects": false,
   "exports": {
+    ".": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.mjs",
+      "require": "./dist/client/index.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.mjs",
@@ -56,12 +61,12 @@
     "vitepress": "^1.0.0"
   },
   "dependencies": {
+    "@iconify-json/carbon": "^1.1.31",
+    "@iconify-json/icon-park-outline": "^1.1.15",
     "@nolebase/ui": "workspace:^",
     "less": "^4.2.0"
   },
   "devDependencies": {
-    "@iconify-json/carbon": "^1.1.31",
-    "@iconify-json/icon-park-outline": "^1.1.15",
     "@rollup/plugin-yaml": "^4.1.2"
   }
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/index.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/index.ts
@@ -24,7 +24,7 @@ import Spotlight from './components/Spotlight.vue'
 import ScreenSpotlight from './components/ScreenSpotlight.vue'
 import SpotlightStyles from './components/SpotlightStyles.vue'
 
-import '@nolebase/ui/client/style.css'
+import '@nolebase/ui/style.css'
 
 export type {
   Options,

--- a/packages/vitepress-plugin-git-changelog/package.json
+++ b/packages/vitepress-plugin-git-changelog/package.json
@@ -29,22 +29,27 @@
   ],
   "sideEffects": false,
   "exports": {
-    "./vite": {
+    ".": {
       "types": "./dist/vite/index.d.ts",
       "import": "./dist/vite/index.mjs",
       "require": "./dist/vite/index.cjs"
-    },
-    "./locales": {
-      "types": "./dist/locales/index.d.ts",
-      "import": "./dist/locales/index.mjs",
-      "require": "./dist/locales/index.cjs"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.mjs",
       "require": "./dist/client/index.js"
     },
-    "./client/style.css": "./dist/client/style.css"
+    "./client/style.css": "./dist/client/style.css",
+    "./locales": {
+      "types": "./dist/locales/index.d.ts",
+      "import": "./dist/locales/index.mjs",
+      "require": "./dist/locales/index.cjs"
+    },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "import": "./dist/vite/index.mjs",
+      "require": "./dist/vite/index.cjs"
+    }
   },
   "main": "./dist/vite/index.cjs",
   "module": "./dist/vite/index.mjs",
@@ -64,6 +69,7 @@
     "vitepress": "^1.0.0"
   },
   "dependencies": {
+    "@iconify-json/octicon": "^1.1.52",
     "@nolebase/ui": "workspace:^",
     "colorette": "^2.0.20",
     "date-fns": "^3.3.1",
@@ -74,7 +80,6 @@
     "uncrypto": "^0.1.3"
   },
   "devDependencies": {
-    "@iconify-json/octicon": "^1.1.52",
     "@rollup/plugin-yaml": "^4.1.2",
     "builtin-modules": "^3.3.0"
   }

--- a/packages/vitepress-plugin-git-changelog/src/client/index.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/index.ts
@@ -7,7 +7,7 @@ import NolebaseGitContributors from './components/Contributors.vue'
 import type { Locale, Options } from './types'
 import { InjectionKey } from './constants'
 
-import '@nolebase/ui/client/style.css'
+import '@nolebase/ui/style.css'
 
 export { default as NolebaseGitChangelog } from './components/Changelog.vue'
 export { default as NolebaseGitContributors } from './components/Contributors.vue'

--- a/packages/vitepress-plugin-highlight-targeted-heading/package.json
+++ b/packages/vitepress-plugin-highlight-targeted-heading/package.json
@@ -26,6 +26,11 @@
   ],
   "sideEffects": false,
   "exports": {
+    ".": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.mjs",
+      "require": "./dist/client/index.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.mjs",

--- a/packages/vitepress-plugin-inline-link-preview/package.json
+++ b/packages/vitepress-plugin-inline-link-preview/package.json
@@ -27,10 +27,10 @@
   ],
   "sideEffects": false,
   "exports": {
-    "./locales": {
-      "types": "./dist/locales/index.d.ts",
-      "import": "./dist/locales/index.mjs",
-      "require": "./dist/locales/index.cjs"
+    ".": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.mjs",
+      "require": "./dist/client/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
@@ -38,6 +38,11 @@
       "require": "./dist/client/index.js"
     },
     "./client/style.css": "./dist/client/style.css",
+    "./locales": {
+      "types": "./dist/locales/index.d.ts",
+      "import": "./dist/locales/index.mjs",
+      "require": "./dist/locales/index.cjs"
+    },
     "./markdown-it": {
       "types": "./dist/markdown-it/index.d.ts",
       "import": "./dist/markdown-it/index.mjs",
@@ -62,6 +67,9 @@
     "vitepress": "^1.0.0"
   },
   "dependencies": {
+    "@iconify-json/icon-park-outline": "^1.1.15",
+    "@iconify-json/octicon": "^1.1.53",
+    "@iconify-json/svg-spinners": "^1.1.2",
     "@nolebase/markdown-it-element-transform": "workspace:^",
     "@nolebase/ui": "workspace:^",
     "less": "^4.2.0",
@@ -69,9 +77,6 @@
     "markdown-it-attrs": "^4.1.6"
   },
   "devDependencies": {
-    "@iconify-json/icon-park-outline": "^1.1.15",
-    "@iconify-json/octicon": "^1.1.53",
-    "@iconify-json/svg-spinners": "^1.1.2",
     "@rollup/plugin-yaml": "^4.1.2",
     "@types/markdown-it": "^13.0.7",
     "@types/markdown-it-attrs": "^4.1.3"

--- a/packages/vitepress-plugin-inline-link-preview/src/client/index.ts
+++ b/packages/vitepress-plugin-inline-link-preview/src/client/index.ts
@@ -6,7 +6,7 @@ import type { Options } from './types'
 import InlineLinkPreview from './components/InlineLinkPreview.vue'
 import PopupIframe from './components/PopupIframe.vue'
 
-import '@nolebase/ui/client/style.css'
+import '@nolebase/ui/style.css'
 
 export type {
   Options,

--- a/packages/vitepress-plugin-og-image/package.json
+++ b/packages/vitepress-plugin-og-image/package.json
@@ -30,6 +30,11 @@
   ],
   "sideEffects": false,
   "exports": {
+    ".": {
+      "types": "./dist/vitepress/index.d.ts",
+      "import": "./dist/vitepress/index.mjs",
+      "require": "./dist/vitepress/index.cjs"
+    },
     "./vitepress": {
       "types": "./dist/vitepress/index.d.ts",
       "import": "./dist/vitepress/index.mjs",

--- a/packages/vitepress-plugin-page-properties/package.json
+++ b/packages/vitepress-plugin-page-properties/package.json
@@ -31,16 +31,21 @@
   ],
   "sideEffects": false,
   "exports": {
-    "./vite": {
-      "types": "./dist/vite/index.d.ts",
-      "import": "./dist/vite/index.mjs",
-      "require": "./dist/vite/index.cjs"
+    ".": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.mjs",
+      "require": "./dist/client/index.js"
     },
-    "./client/style.css": "./dist/client/style.css",
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.mjs",
       "require": "./dist/client/index.js"
+    },
+    "./client/style.css": "./dist/client/style.css",
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "import": "./dist/vite/index.mjs",
+      "require": "./dist/vite/index.cjs"
     }
   },
   "main": "./dist/client/index.js",
@@ -61,6 +66,8 @@
     "vitepress": "^1.0.0"
   },
   "dependencies": {
+    "@iconify-json/icon-park-outline": "^1.1.15",
+    "@iconify-json/octicon": "^1.1.53",
     "@nolebase/ui": "workspace:^",
     "date-fns": "^3.3.1",
     "gray-matter": "^4.0.3",
@@ -69,8 +76,6 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@iconify-json/icon-park-outline": "^1.1.15",
-    "@iconify-json/octicon": "^1.1.53",
     "@rollup/plugin-yaml": "^4.1.2",
     "@types/markdown-it": "^13.0.7",
     "@types/uuid": "^9.0.8",

--- a/packages/vitepress-plugin-page-properties/src/client/index.ts
+++ b/packages/vitepress-plugin-page-properties/src/client/index.ts
@@ -20,7 +20,7 @@ import { InjectionKey } from './constants'
 import NolebasePageProperties from './components/PageProperties.vue'
 import NolebasePagePropertiesEditor from './components/PagePropertiesEditor.vue'
 
-import '@nolebase/ui/client/style.css'
+import '@nolebase/ui/style.css'
 
 const components = {
   NolebasePageProperties,

--- a/packages/vitepress-plugin-thumbnail-hash/package.json
+++ b/packages/vitepress-plugin-thumbnail-hash/package.json
@@ -28,7 +28,7 @@
   ],
   "sideEffects": false,
   "exports": {
-    "./vite": {
+    ".": {
       "types": "./dist/vite/index.d.ts",
       "import": "./dist/vite/index.mjs",
       "require": "./dist/vite/index.cjs"
@@ -37,6 +37,11 @@
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.mjs",
       "require": "./dist/client/index.js"
+    },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "import": "./dist/vite/index.mjs",
+      "require": "./dist/vite/index.cjs"
     }
   },
   "main": "./dist/vite/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@iconify-json/octicon':
+        specifier: ^1.1.53
+        version: 1.1.53
       '@rive-app/canvas':
         specifier: ^2.11.1
         version: 2.11.1
@@ -273,6 +276,12 @@ importers:
 
   packages/vitepress-plugin-enhanced-readabilities:
     dependencies:
+      '@iconify-json/carbon':
+        specifier: ^1.1.31
+        version: 1.1.31
+      '@iconify-json/icon-park-outline':
+        specifier: ^1.1.15
+        version: 1.1.15
       '@nolebase/ui':
         specifier: workspace:^
         version: link:../ui
@@ -283,18 +292,15 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2(@algolia/client-search@4.22.1)(@types/node@20.12.5)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.4)
     devDependencies:
-      '@iconify-json/carbon':
-        specifier: ^1.1.31
-        version: 1.1.31
-      '@iconify-json/icon-park-outline':
-        specifier: ^1.1.15
-        version: 1.1.15
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@3.29.4)
 
   packages/vitepress-plugin-git-changelog:
     dependencies:
+      '@iconify-json/octicon':
+        specifier: ^1.1.52
+        version: 1.1.52
       '@nolebase/ui':
         specifier: workspace:^
         version: link:../ui
@@ -323,9 +329,6 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2(@algolia/client-search@4.22.1)(@types/node@20.12.5)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.4)
     devDependencies:
-      '@iconify-json/octicon':
-        specifier: ^1.1.52
-        version: 1.1.52
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@3.29.4)
@@ -344,6 +347,15 @@ importers:
 
   packages/vitepress-plugin-inline-link-preview:
     dependencies:
+      '@iconify-json/icon-park-outline':
+        specifier: ^1.1.15
+        version: 1.1.15
+      '@iconify-json/octicon':
+        specifier: ^1.1.53
+        version: 1.1.53
+      '@iconify-json/svg-spinners':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@nolebase/markdown-it-element-transform':
         specifier: workspace:^
         version: link:../markdown-it-element-transform
@@ -363,15 +375,6 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2(@algolia/client-search@4.22.1)(@types/node@20.12.5)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.4)
     devDependencies:
-      '@iconify-json/icon-park-outline':
-        specifier: ^1.1.15
-        version: 1.1.15
-      '@iconify-json/octicon':
-        specifier: ^1.1.53
-        version: 1.1.53
-      '@iconify-json/svg-spinners':
-        specifier: ^1.1.2
-        version: 1.1.2
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@3.29.4)
@@ -430,6 +433,12 @@ importers:
 
   packages/vitepress-plugin-page-properties:
     dependencies:
+      '@iconify-json/icon-park-outline':
+        specifier: ^1.1.15
+        version: 1.1.15
+      '@iconify-json/octicon':
+        specifier: ^1.1.53
+        version: 1.1.53
       '@nolebase/ui':
         specifier: workspace:^
         version: link:../ui
@@ -452,12 +461,6 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2(@algolia/client-search@4.22.1)(@types/node@20.12.5)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.4)
     devDependencies:
-      '@iconify-json/icon-park-outline':
-        specifier: ^1.1.15
-        version: 1.1.15
-      '@iconify-json/octicon':
-        specifier: ^1.1.53
-        version: 1.1.53
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@3.29.4)
@@ -1659,35 +1662,30 @@ packages:
     resolution: {integrity: sha512-CAvECFfiwGyZmlcuM2JLMRDEN3VsIEZv6lml7Xf+3giQ5oXloADm0b5wiVPFZmONKM5jXERmx+E7YSvAtFJIbw==}
     dependencies:
       '@iconify/types': 2.0.0
-    dev: true
 
   /@iconify-json/icon-park-outline@1.1.15:
     resolution: {integrity: sha512-jQbk/ETARyYPjX6HolkdjSLJHsNCfSBfYUqcUQLXYK/1tfuVnQsUdWG2IM2a7VBpxJtrK7r4n1iwPOFaZ5T46g==}
     dependencies:
       '@iconify/types': 2.0.0
-    dev: true
 
   /@iconify-json/octicon@1.1.52:
     resolution: {integrity: sha512-0bLc9t54p55nVlQ8SKF7BYOBTy/Q5SfvqYcOD09APDksRTikO45MwKTfG3fzkbaIwpobuVQM1sXiSCsyWJX9Tg==}
     dependencies:
       '@iconify/types': 2.0.0
-    dev: true
+    dev: false
 
   /@iconify-json/octicon@1.1.53:
     resolution: {integrity: sha512-QaVwZsO7v4F5J1oj3uhxLXYA4fCzrvWFlruyMXOhUDZtrKTc6Vb5nIO1b7A4NOwzlTW638XZzHW70PnE0V0F8g==}
     dependencies:
       '@iconify/types': 2.0.0
-    dev: true
 
   /@iconify-json/svg-spinners@1.1.2:
     resolution: {integrity: sha512-Aab6SqkORaTJ1W+ooufn6C8BsBitrn3uk8iRQLPA6pjhyvQAhkKCGMctyXIL5ZjrycnoFVsZ4mx7KnwEMra8qg==}
     dependencies:
       '@iconify/types': 2.0.0
-    dev: true
 
   /@iconify/types@2.0.0:
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
-    dev: true
 
   /@iconify/utils@2.1.22:
     resolution: {integrity: sha512-6UHVzTVXmvO8uS6xFF+L/QTSpTzA/JZxtgU+KYGFyDYMEObZ1bu/b5l+zNJjHy+0leWjHI+C0pXlzGvv3oXZMA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@types/markdown-it-footnote':
         specifier: ^3.0.4
         version: 3.0.4
+      asciinema-player:
+        specifier: ^3.7.1
+        version: 3.7.1
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -3779,7 +3782,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       solid-js: 1.8.16
-    dev: false
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -7416,12 +7418,10 @@ packages:
       seroval: ^1.0
     dependencies:
       seroval: 1.0.5
-    dev: false
 
   /seroval@1.0.5:
     resolution: {integrity: sha512-TM+Z11tHHvQVQKeNlOUonOWnsNM+2IBwZ4vwoi4j3zKzIpc5IDw8WPwCfcc8F17wy6cBcJGbZbFOR0UCuTZHQA==}
     engines: {node: '>=10'}
-    dev: false
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7492,7 +7492,6 @@ packages:
       csstype: 3.1.3
       seroval: 1.0.5
       seroval-plugins: 1.0.5(seroval@1.0.5)
-    dev: false
 
   /source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}


### PR DESCRIPTION
```
Internal server error: 
Failed to resolve import "@nolebase/ui/client/style.css" from "node_modules/.pnpm/@nolebase+vitepress-plugin-git-changelog@2.0.0-rc6_vitepress@1.1.0_vue@3.4.21/node_modules/@nolebase/vitepress-plugin-git-changelog/dist/client/index.mjs?v=90fb9ea1".

Does the file exist?
```

1. Missing `@nolebase/ui/style.css` exports

```json
{
  "exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "import": "./dist/index.mjs",
      "require": "./dist/index.js"
    },
    "./*": {
      "types": "./dist/*",
      "import": "./dist/*.mjs",
      "require": "./dist/*.js"
    }
  }
}
```

2. Bad build exports for `@nolebase/ui/client/style.css` in `@nolebase/ui`, should be `@nolebase/ui/style.css`.
3. Bad import for `@nolebase/ui/client/style.css` from all the other packages, should be `@nolebase/ui/style.css`
4. Bad configuration for `vite-omit-replacing`, it should be mismatched previously...