### PR TITLE
fix: disable spinner in production mode

### DIFF
--- a/packages/vitepress-plugin-git-changelog/src/vite/git.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/git.ts
@@ -88,7 +88,7 @@ export function GitChangelog(options: GitChangelogOptions = {}): Plugin {
     async buildStart() {
       const startsAt = Date.now()
 
-      const spinner = ora({ discardStdin: false, isSilent: config.command === 'build' })
+      const spinner = ora({ discardStdin: false, isEnabled: config.command === 'serve' })
 
       spinner.start(`${logModulePrefix} Prepare to gather git logs...`)
 

--- a/packages/vitepress-plugin-git-changelog/src/vite/git.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/git.ts
@@ -1,5 +1,6 @@
 import { cwd as _cwd } from 'node:process'
-import type { Plugin } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
+import type { SiteConfig } from 'vitepress'
 import ora from 'ora'
 import { cyan, gray } from 'colorette'
 import { globby } from 'globby'
@@ -30,6 +31,10 @@ export {
   rewritePathsByRewritingExtension,
 }
 
+interface VitePressConfig extends ResolvedConfig {
+  vitepress: SiteConfig
+}
+
 const VirtualModuleID = 'virtual:nolebase-git-changelog'
 const ResolvedVirtualModuleId = `\0${VirtualModuleID}`
 
@@ -51,7 +56,7 @@ export function GitChangelog(options: GitChangelogOptions = {}): Plugin {
   } = options
 
   let commits: Commit[] = []
-  let srcDir = ''
+  let config: VitePressConfig
 
   return {
     name: '@nolebase/vitepress-plugin-git-changelog',
@@ -77,14 +82,15 @@ export function GitChangelog(options: GitChangelogOptions = {}): Plugin {
         ],
       },
     }),
-    configResolved(config) {
-      // @ts-expect-error The vitepress configuration is included in the vite configuration
-      srcDir = config.vitepress.srcDir
+    configResolved(_config) {
+      config = _config as VitePressConfig
     },
     async buildStart() {
       const startsAt = Date.now()
 
-      const spinner = ora(`${logModulePrefix} Prepare to gather git logs...`).start()
+      const spinner = ora({ discardStdin: false, isSilent: config.command === 'build' })
+
+      spinner.start(`${logModulePrefix} Prepare to gather git logs...`)
 
       const getRepoURL = typeof repoURL === 'function' ? repoURL : () => repoURL
 
@@ -102,6 +108,8 @@ export function GitChangelog(options: GitChangelogOptions = {}): Plugin {
         cwd,
         absolute: true,
       })
+
+      const srcDir = config.vitepress.srcDir
 
       commits = (await Promise.all(
         paths.map(async (path) => {

--- a/packages/vitepress-plugin-thumbnail-hash/src/vite/index.ts
+++ b/packages/vitepress-plugin-thumbnail-hash/src/vite/index.ts
@@ -128,7 +128,7 @@ export function ThumbnailHashImages(): Plugin {
       const grayPrefix = gray(':')
       const spinnerPrefix = `${moduleNamePrefix}${grayPrefix}`
 
-      const spinner = ora({ discardStdin: false, isSilent: config.command === 'build' })
+      const spinner = ora({ discardStdin: false, isEnabled: config.command === 'serve' })
 
       spinner.start(`${spinnerPrefix} Prepare to generate hashes for images...`)
 

--- a/packages/vitepress-plugin-thumbnail-hash/src/vite/index.ts
+++ b/packages/vitepress-plugin-thumbnail-hash/src/vite/index.ts
@@ -128,7 +128,9 @@ export function ThumbnailHashImages(): Plugin {
       const grayPrefix = gray(':')
       const spinnerPrefix = `${moduleNamePrefix}${grayPrefix}`
 
-      const spinner = ora(`${spinnerPrefix} Prepare to generate hashes for images...`).start()
+      const spinner = ora({ discardStdin: false, isSilent: config.command === 'build' })
+
+      spinner.start(`${spinnerPrefix} Prepare to generate hashes for images...`)
 
       const cacheDir = join(vitepressConfig.cacheDir, '@nolebase', 'vitepress-plugin-thumbnail-hash', 'thumbhashes')
       await mkdir(cacheDir, { recursive: true })


### PR DESCRIPTION
涉及插件：git-changelog、ThumbnailHashImages

修复在 build 结束后插件的 spinner 还在转动，build 进程没有退出的问题。ref: https://github.com/nolebase/integrations/issues/191#issuecomment-2095003014

before:

![image](https://github.com/nolebase/integrations/assets/44738481/44100be5-1e1a-480b-9a03-59edc8d48294)


after:

![image](https://github.com/nolebase/integrations/assets/44738481/450605ce-62ae-4cd1-affd-4f5abcfc6264)


VitePress 在 build 时，为 `building client + server bundles...` 和 `rendering pages...` 分别启动了一个 ora 实例，插件启动的 ora 实例在 `building client + server bundles...` 这一步结束前，相当于 build 时，同时启动了两个 spinner 。

而 ora 尚不支持同时启动两个 spinner ：https://github.com/sindresorhus/ora/issues/116 。

因此我们需要在 build 时禁用插件的 spinner。

其他替代方案：

- 使用其他 spinner 库，例如 https://github.com/listr2/listr2
- 向 VitePress 反馈（大概率行不通）