### PR TITLE
fix(git-changelog): block element should not be warpped in inline element

### DIFF
--- a/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
@@ -133,11 +133,10 @@ async function handleCommitAuthors(map: Record<string, ContributorInfo>, authorN
         <a
           v-if="(typeof c.url !== 'undefined')"
           :href="c.url"
+          class="flex items-center gap-2"
         >
-          <div class="flex items-center gap-2">
-            <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
-            {{ c.name }}
-          </div>
+          <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
+          {{ c.name }}
         </a>
         <div
           v-else


### PR DESCRIPTION
before:

![Snipaste_2024-05-06_20-01-37](https://github.com/nolebase/integrations/assets/44738481/2fe0a06e-65eb-41a9-80db-179e733a7d70)


after:

![image](https://github.com/nolebase/integrations/assets/44738481/a4ae802a-fe3b-4986-ae5e-223b5346adc7)
