### PR TITLE
fix(git-changelog): mapAuthors.name also include in nameAlias, default return github link when no links but with username

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -57,20 +57,23 @@ export default defineThemeUnconfig({
           mapContributors: [
             {
               name: 'Neko',
-              avatar: 'https://github.com/nekomeowww.png',
+              username: 'nekomeowww',
               mapByNameAliases: ['Neko Ayaka', 'Ayaka Neko'],
               mapByEmailAliases: ['neko@ayaka.moe'],
             },
             {
               name: 'Rizumu',
-              avatar: 'https://github.com/LittleSound.png',
+              username: 'LittleSound',
               mapByNameAliases: ['Rizumu Ayaka', 'Ayaka Rizumu'],
               mapByEmailAliases: ['rizumu@ayaka.moe'],
             },
             {
               name: 'Nisekoi5',
-              avatar: 'https://github.com/Nisekoi5.png',
-              mapByNameAliases: ['Nisekoi5'],
+              username: 'Nisekoi5',
+            },
+            {
+              name: 'Northword',
+              username: 'northword',
             },
           ],
         },

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/author.test.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/author.test.ts
@@ -27,11 +27,22 @@ describe('findMapAuthorByName', () => {
     const creators: Contributor[] = [
       {
         name: 'John Doe',
-        mapByNameAliases: ['John Doe'],
       },
     ]
 
     const creator = findMapAuthorByName(creators, 'John Doe')
+    expect(creator).toEqual(creators[0])
+  })
+
+  it('should return the registered creator by nameAliases', () => {
+    const creators: Contributor[] = [
+      {
+        name: 'John Doe',
+        mapByNameAliases: ['Johndoe'],
+      },
+    ]
+
+    const creator = findMapAuthorByName(creators, 'Johndoe')
     expect(creator).toEqual(creators[0])
   })
 })

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/author.test.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/author.test.ts
@@ -129,6 +129,45 @@ describe('findMapAuthorLink', () => {
     const link = findMapAuthorLink(creator)
     expect(link).toEqual('example.com')
   })
+
+  it('should return the registered creator link with no links', () => {
+    const creator: Contributor = {
+      name: 'John Doe',
+      username: 'johndoe',
+    }
+
+    const link = findMapAuthorLink(creator)
+    expect(link).toEqual('https://github.com/johndoe')
+  })
+
+  it('should return undefined when no links and username', () => {
+    const creator: Contributor = {
+      name: 'John Doe',
+    }
+
+    const link = findMapAuthorLink(creator)
+    expect(link).toEqual(undefined)
+  })
+
+  it('should return undefined when links is empty string', () => {
+    const creator: Contributor = {
+      name: 'John Doe',
+      links: '',
+    }
+
+    const link = findMapAuthorLink(creator)
+    expect(link).toEqual(undefined)
+  })
+
+  it('should return undefined when links is empty array', () => {
+    const creator: Contributor = {
+      name: 'John Doe',
+      links: [],
+    }
+
+    const link = findMapAuthorLink(creator)
+    expect(link).toEqual(undefined)
+  })
 })
 
 describe('newAvatarForAuthor', () => {

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/author.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/author.ts
@@ -10,7 +10,7 @@ export interface AuthorInfo {
 
 export function findMapAuthorByName(mapContributors: Contributor[] | undefined, author_name: string) {
   return mapContributors?.find((item) => {
-    const res = item.mapByNameAliases && Array.isArray(item.mapByNameAliases) && item.mapByNameAliases.includes(author_name)
+    const res = (item.mapByNameAliases && Array.isArray(item.mapByNameAliases) && item.mapByNameAliases.includes(author_name)) || item.name === author_name
     if (res)
       return true
 

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/author.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/author.ts
@@ -31,13 +31,13 @@ export function findMapAuthorByEmail(mapContributors: Contributor[] | undefined,
 }
 
 export function findMapAuthorLink(creator: Contributor): string | undefined {
+  if (!creator.links && !!creator.username)
+    return `https://github.com/${creator.username}`
+
   if (typeof creator.links === 'string' && !!creator.links)
     return creator.links
   if (!Array.isArray(creator.links))
     return
-
-  if (!creator.links && !!creator.username)
-    return `https://github.com/${creator.username}`
 
   const priority = ['github', 'twitter']
   for (const p of priority) {


### PR DESCRIPTION
Supplement to #210