### PR TITLE
fix(enhanced-readabilities): [unocss] failed to load icon

### DIFF
--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitch.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitch.vue
@@ -131,7 +131,9 @@ onMounted(() => {
         :disabled="disabled"
         pr-4
       >
-        <span i-icon-park-outline:layout-one />
+        <template #icon>
+          <span i-icon-park-outline:layout-one mr-1 aria-hidden="true" />
+        </template>
       </MenuTitle>
       <MenuHelp
         v-if="!options.layoutSwitch?.disableHelp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitch.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitch.vue
@@ -125,13 +125,14 @@ onMounted(() => {
   <div space-y-2 role="radiogroup">
     <div ref="menuTitleElementRef" flex items-center>
       <MenuTitle
-        icon="i-icon-park-outline:layout-one"
         :title="t('layoutSwitch.title')"
         :aria-label="t('layoutSwitch.titleAriaLabel') || t('layoutSwitch.title')"
         flex="1"
         :disabled="disabled"
         pr-4
-      />
+      >
+        <span i-icon-park-outline:layout-one />
+      </MenuTitle>
       <MenuHelp
         v-if="!options.layoutSwitch?.disableHelp"
         v-model:is-popped-up="isMenuHelpPoppedUp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchContentLayoutMaxWidthSlider.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchContentLayoutMaxWidthSlider.vue
@@ -112,6 +112,9 @@ watch(maxWidthValue, (val) => {
           flex="1"
           pr-4
         >
+          <template #icon>
+            <span i-icon-park-outline:layout-one mr-1 aria-hidden="true" />
+          </template>
           <span i-icon-park-outline:auto-line-width />
         </MenuTitle>
         <MenuHelp

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchContentLayoutMaxWidthSlider.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchContentLayoutMaxWidthSlider.vue
@@ -106,13 +106,14 @@ watch(maxWidthValue, (val) => {
     >
       <div ref="menuTitleElementRef" flex items-center>
         <MenuTitle
-          icon="i-icon-park-outline:auto-line-width"
           :title="t('layoutSwitch.contentLayoutMaxWidth.title')"
           :aria-label="t('layoutSwitch.contentLayoutMaxWidth.titleAriaLabel') || t('layoutSwitch.contentLayoutMaxWidth.title')"
           :disabled="disabled"
           flex="1"
           pr-4
-        />
+        >
+          <span i-icon-park-outline:auto-line-width />
+        </MenuTitle>
         <MenuHelp
           v-if="!options.layoutSwitch?.contentLayoutMaxWidth?.disableHelp"
           v-model:is-popped-up="isMenuHelpPoppedUp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchPageLayoutMaxWidthSlider.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchPageLayoutMaxWidthSlider.vue
@@ -111,7 +111,9 @@ watch(maxWidthValue, (val) => {
           flex="1"
           pr-2
         >
-          <span i-icon-park-outline:auto-width-one />
+          <template #icon>
+            <span i-icon-park-outline:auto-width-one mr-1 aria-hidden="true" />
+          </template>
         </MenuTitle>
         <MenuHelp
           v-if="!options.layoutSwitch?.pageLayoutMaxWidth?.disableHelp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchPageLayoutMaxWidthSlider.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/LayoutSwitchPageLayoutMaxWidthSlider.vue
@@ -105,13 +105,14 @@ watch(maxWidthValue, (val) => {
     >
       <div ref="menuTitleElementRef" flex items-center>
         <MenuTitle
-          icon="i-icon-park-outline:auto-width-one"
           :title="t('layoutSwitch.pageLayoutMaxWidth.title')"
           :aria-label="t('layoutSwitch.pageLayoutMaxWidth.titleAriaLabel') || t('layoutSwitch.pageLayoutMaxWidth.title')"
           :disabled="disabled"
           flex="1"
           pr-2
-        />
+        >
+          <span i-icon-park-outline:auto-width-one />
+        </MenuTitle>
         <MenuHelp
           v-if="!options.layoutSwitch?.pageLayoutMaxWidth?.disableHelp"
           v-model:is-popped-up="isMenuHelpPoppedUp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/MenuTitle.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/MenuTitle.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
     text="[14px] $vp-nolebase-enhanced-readabilities-menu-text-color"
     inline-flex select-none items-center align-middle font-medium
   >
-    <slot name="icon" mr-1 aria-hidden="true" />
+    <slot name="icon" />
     <span v-if="props.title">{{ props.title }}</span>
     <slot />
   </h3>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/MenuTitle.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/MenuTitle.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 const props = defineProps<{
   title?: string
-  icon?: string
   disabled?: boolean
 }>()
 </script>
@@ -14,7 +13,7 @@ const props = defineProps<{
     text="[14px] $vp-nolebase-enhanced-readabilities-menu-text-color"
     inline-flex select-none items-center align-middle font-medium
   >
-    <span v-if="props.icon" :class="props.icon" mr-1 aria-hidden="true" />
+    <slot name="icon" mr-1 aria-hidden="true" />
     <span v-if="props.title">{{ props.title }}</span>
     <slot />
   </h3>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenLayoutSwitch.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenLayoutSwitch.vue
@@ -44,11 +44,12 @@ const fieldOptions = computed(() => [
 <template>
   <div space-y-2>
     <MenuTitle
-      icon="i-icon-park-outline:layout-one"
       :title="t('layoutSwitch.title')"
       :aria-label="t('layoutSwitch.titleAriaLabel') || t('layoutSwitch.title')"
       disabled
-    />
+    >
+      <slot i-icon-park-outline:layout-one />
+    </MenuTitle>
     <div border="1 red/50 solid" bg="red/30" flex items-center rounded-lg p-2 opacity-50>
       <span text-xs>{{ t('layoutSwitch.titleScreenNavWarningMessage') }}</span>
     </div>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenLayoutSwitch.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenLayoutSwitch.vue
@@ -48,7 +48,9 @@ const fieldOptions = computed(() => [
       :aria-label="t('layoutSwitch.titleAriaLabel') || t('layoutSwitch.title')"
       disabled
     >
-      <slot i-icon-park-outline:layout-one />
+      <template #icon>
+        <slot i-icon-park-outline:layout-one mr-1 aria-hidden="true" />
+      </template>
     </MenuTitle>
     <div border="1 red/50 solid" bg="red/30" flex items-center rounded-lg p-2 opacity-50>
       <span text-xs>{{ t('layoutSwitch.titleScreenNavWarningMessage') }}</span>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenMenu.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenMenu.vue
@@ -12,10 +12,11 @@ const { t } = useI18n()
 <template>
   <div v-if="mounted" space-y-2 class="VPNolebaseEnhancedReadabilitiesMenu">
     <MenuTitle
-      icon="i-icon-park-outline:book-open"
       :title="t('title.title')"
       :aria-label="t('title.titleAriaLabel') || t('title.title')"
-    />
+    >
+      <span i-icon-park-outline:book-open />
+    </MenuTitle>
     <div flex="~ col" pl-4 space-y-2>
       <ScreenLayoutSwitch />
       <ScreenSpotlight />

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenMenu.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenMenu.vue
@@ -15,7 +15,9 @@ const { t } = useI18n()
       :title="t('title.title')"
       :aria-label="t('title.titleAriaLabel') || t('title.title')"
     >
-      <span i-icon-park-outline:book-open />
+      <template #icon>
+        <span i-icon-park-outline:book-open mr-1 aria-hidden="true" />
+      </template>
     </MenuTitle>
     <div flex="~ col" pl-4 space-y-2>
       <ScreenLayoutSwitch />

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenSpotlight.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenSpotlight.vue
@@ -33,7 +33,9 @@ const fieldOptions = computed(() => [
       :aria-label="t('spotlight.titleAriaLabel') || t('spotlight.title')"
       disabled
     >
-      <span i-icon-park-outline:click />
+      <template #icon>
+        <span i-icon-park-outline:click mr-1 aria-hidden="true" />
+      </template>
     </MenuTitle>
     <div border="1 red/50 solid" bg="red/30" flex items-center rounded-lg p-2 opacity-50>
       <span text-xs>{{ t('spotlight.titleScreenNavWarningMessage') }}</span>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenSpotlight.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/ScreenSpotlight.vue
@@ -29,11 +29,12 @@ const fieldOptions = computed(() => [
 <template>
   <div space-y-2>
     <MenuTitle
-      icon="i-icon-park-outline:click"
       :title="t('spotlight.title')"
       :aria-label="t('spotlight.titleAriaLabel') || t('spotlight.title')"
       disabled
-    />
+    >
+      <span i-icon-park-outline:click />
+    </MenuTitle>
     <div border="1 red/50 solid" bg="red/30" flex items-center rounded-lg p-2 opacity-50>
       <span text-xs>{{ t('spotlight.titleScreenNavWarningMessage') }}</span>
     </div>

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/Spotlight.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/Spotlight.vue
@@ -60,7 +60,9 @@ watch(isTouchScreen, () => {
         flex="1"
         pr-4
       >
-        <span i-icon-park-outline:click />
+        <template #icon>
+          <span i-icon-park-outline:click mr-1 aria-hidden="true" />
+        </template>
       </MenuTitle>
       <MenuHelp
         v-if="!options.spotlight?.disableHelp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/Spotlight.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/Spotlight.vue
@@ -54,13 +54,14 @@ watch(isTouchScreen, () => {
     />
     <div ref="menuTitleElementRef" relative flex items-center>
       <MenuTitle
-        icon="i-icon-park-outline:click"
         :title="t('spotlight.title')"
         :aria-label="t('spotlight.titleAriaLabel') || t('spotlight.title')"
         :disabled="disabled"
         flex="1"
         pr-4
-      />
+      >
+        <span i-icon-park-outline:click />
+      </MenuTitle>
       <MenuHelp
         v-if="!options.spotlight?.disableHelp"
         v-model:is-popped-up="isMenuHelpPoppedUp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightStyles.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightStyles.vue
@@ -56,13 +56,14 @@ watch(isTouchScreen, () => {
     >
       <div ref="menuTitleElementRef" relative flex items-center>
         <MenuTitle
-          icon="i-icon-park-outline:click"
           :title="t('spotlight.styles.title')"
           :aria-label="t('spotlight.styles.titleAriaLabel') || t('spotlight.styles.title')"
           :disabled="disabled"
           flex="1"
           pr-4
-        />
+        >
+          <span i-icon-park-outline:click />
+        </MenuTitle>
         <MenuHelp
           v-if="!options.spotlight?.disableHelp"
           v-model:is-popped-up="isMenuHelpPoppedUp"

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightStyles.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightStyles.vue
@@ -62,7 +62,9 @@ watch(isTouchScreen, () => {
           flex="1"
           pr-4
         >
-          <span i-icon-park-outline:click />
+          <template #icon>
+            <span i-icon-park-outline:click mr-1 aria-hidden="true" />
+          </template>
         </MenuTitle>
         <MenuHelp
           v-if="!options.spotlight?.disableHelp"


### PR DESCRIPTION
Fix

```shell
[unocss] failed to load icon "icon-park-outline:icon-book-open"
```

Issue.

But I still think this is related to @unocss. Since we used the attribute `icon="i-icon-park-outline:layout-one"` to specify the icons, may result `unocss` to think `i-icon-park-outline:layout-one` is some sort of the `icon` that needs to be transformed with.