### PR TITLE
refactor(git-changelog): use a 7-digit commit hash instead of a 5-digit

### DIFF
--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
@@ -21,7 +21,7 @@ const { t } = useI18n()
         transition="color ease-in-out"
         duration-200
       >
-        {{ commit.hash.slice(0, 5) }}
+        {{ commit.hash.slice(0, 7) }}
       </code>
     </a>
     <span>-</span>


### PR DESCRIPTION
closed #216 