### PR TITLE
fix(git-changelog): hydration mismatch when timezone mismatch, invalid commit when empty

### DIFF
--- a/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
@@ -23,6 +23,8 @@ const { lang, page } = useData()
 const { t } = useI18n()
 const { commits, update } = useCommits(page)
 
+const lastChangeDate = ref<Date>(toDate(commits.value[0]?.date_timestamp))
+
 onMounted(() => {
   if (import.meta.hot) {
     import.meta.hot.send('nolebase-git-changelog:client-mounted', {
@@ -57,8 +59,8 @@ onMounted(() => {
   }
 })
 
-const lastChangeDate = computed<Date>(() => {
-  return toDate(commits.value[0]?.date_timestamp)
+onMounted(() => {
+  lastChangeDate.value = toDate(commits.value[0]?.date_timestamp)
 })
 
 const locale = computed<Locale>(() => {

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.test.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.test.ts
@@ -116,7 +116,10 @@ describe('parseCommits', () => {
   })
 
   it('should transform for commit contains no refs', async () => {
-    const mockedCommit = ['62ef7ed8f54ea1faeacf6f6c574df491814ec1b1|First Last|user@example.com|Wed Apr 24 14:24:44 2024 +0800|docs: fix english integrations list||Signed-off-by: First Last <user@example.com>\n']
+    const mockedCommit = [
+      '', // empty commit, could occur when the file contains no history or git cli bugged
+      '62ef7ed8f54ea1faeacf6f6c574df491814ec1b1|First Last|user@example.com|Wed Apr 24 14:24:44 2024 +0800|docs: fix english integrations list||Signed-off-by: First Last <user@example.com>\n',
+    ]
     const commit = await parseCommits(
       '',
       mockedCommit,
@@ -142,7 +145,10 @@ describe('parseCommits', () => {
   })
 
   it('should transform for commit contains no body', async () => {
-    const mockedCommit = ['fa0fb328b988499c74983e9164f6db4e2e92afd8|First Last|user@example.com|Sun Apr 7 22:27:57 2024 +0800|release: v1.28.0| (tag: v1.28.0)|']
+    const mockedCommit = [
+      '', // empty commit, could occur when the file contains no history or git cli bugged
+      'fa0fb328b988499c74983e9164f6db4e2e92afd8|First Last|user@example.com|Sun Apr 7 22:27:57 2024 +0800|release: v1.28.0| (tag: v1.28.0)|',
+    ]
     const commit = await parseCommits(
       '',
       mockedCommit,
@@ -169,5 +175,21 @@ describe('parseCommits', () => {
       release_tag_url: 'https://github.com/example-org/example/releases/tag/v1.28.0',
       release_tags_url: ['https://github.com/example-org/example/releases/tag/v1.28.0'],
     }])
+  })
+
+  it('should return no commits when empty', async () => {
+    const mockedCommit = [
+      '', // empty commit, could occur when the file contains no history or git cli bugged
+    ]
+    const commit = await parseCommits(
+      '',
+      mockedCommit,
+      () => 'https://github.com/example-org/example',
+      defaultCommitURLHandler,
+      defaultReleaseTagURLHandler,
+      defaultReleaseTagsURLHandler,
+    )
+
+    expect(commit).toEqual([])
   })
 })

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
@@ -264,6 +264,8 @@ export async function parseCommits(
   getReleaseTagsURL: CommitToStringsHandler,
   optsRewritePathsBy?: RewritePathsBy,
 ): Promise<Commit[]> {
+  rawLogs = rawLogs.filter(log => !!log)
+
   const commits = await Promise.all(rawLogs.map(async (raw) => {
     const [hash, author_name, author_email, date, message, refs, body] = raw.split('|').map(v => v.trim())
     const commit: Commit = {


### PR DESCRIPTION
Close #220 

<img width="757" alt="image" src="https://github.com/nolebase/integrations/assets/11081491/32905616-9aa7-45ca-8530-17c349d5f115">

Hydration mismatch for page https://nolebase-integrations.ayaka.io/pages/en/integrations/ over commit 812aa3b .