### PR TITLE
fix(bi-directional-links): trim src + including non-attachment markup

### DIFF
--- a/packages/markdown-it-bi-directional-links/src/index.ts
+++ b/packages/markdown-it-bi-directional-links/src/index.ts
@@ -256,14 +256,12 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => (md: M
         return false
       }
 
-      const isAttachmentRef = link.input.startsWith('!')
-
       const inputContent = link.input
       const markupTextContent = link[0]
       const href = link[1].trim() // href is the file name, uses posix style
       const text = link[3]?.trim() ?? ''
 
-      const isImageRef = isAttachmentRef && IMAGES_EXTENSIONS.some(ext => href.endsWith(ext))
+      const isImageRef = IMAGES_EXTENSIONS.some(ext => href.endsWith(ext))
 
       // Extract the pathname from the href
       const parsedHref = new URL(href, 'https://a.com')

--- a/packages/markdown-it-bi-directional-links/src/index.ts
+++ b/packages/markdown-it-bi-directional-links/src/index.ts
@@ -260,8 +260,8 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => (md: M
 
       const inputContent = link.input
       const markupTextContent = link[0]
-      const href = link[1] // href is the file name, uses posix style
-      const text = link[3] ?? ''
+      const href = link[1].trim() // href is the file name, uses posix style
+      const text = link[3]?.trim() ?? ''
 
       const isImageRef = isAttachmentRef && IMAGES_EXTENSIONS.some(ext => href.endsWith(ext))
 


### PR DESCRIPTION
Reason 1: The image path may have space around

<img width="502" alt="image" src="https://github.com/nolebase/integrations/assets/42423957/503f75d2-e5bf-4900-b4ae-4220516189b6">

Reason2: The attachment should only recognized by extension

The image maybe [[image.png]] instead of ![[image.png]]