### PR TITLE
feat(og image): enhanced configuration, image URL support

### DIFF
--- a/packages/vitepress-plugin-og-image/package.json
+++ b/packages/vitepress-plugin-og-image/package.json
@@ -70,6 +70,7 @@
     "rehype-parse": "^9.0.0",
     "rehype-stringify": "^10.0.0",
     "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0",
     "vitepress": "^1.2.3"
   },
   "devDependencies": {

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -111,14 +111,18 @@ async function renderSVGAndRewriteHTML(
     ogImageTemplateSvg,
   )
 
+  let width: number
+  let height: number
   try {
-    await renderSVGAndSavePNG(
+    const res = await renderSVGAndSavePNG(
       templatedOgImageSvg,
       ogImageFilePathFullName,
       ogImageTemplateSvgPath,
       relative(siteConfig.srcDir, file),
       { fontPath: await tryToLocateFontFile(siteConfig), imageUrlResolver, additionalFontBuffers },
     )
+    width = res.width
+    height = res.height
   }
   catch (err) {
     return {
@@ -135,6 +139,8 @@ async function renderSVGAndRewriteHTML(
       twitter: true,
       image: {
         url: `${domain}/${relative(siteConfig.outDir, ogImageFilePathFullName).replaceAll(sep, '/')}`,
+        width,
+        height,
       },
     })
     .use(RehypeStringify)
@@ -174,7 +180,7 @@ async function renderSVGAndSavePNG(
   },
 ) {
   try {
-    const pngBuffer = await renderSVG(svgContent, await initFontBuffer(options), options.imageUrlResolver, options.additionalFontBuffers)
+    const { png: pngBuffer, width, height } = await renderSVG(svgContent, await initFontBuffer(options), options.imageUrlResolver, options.additionalFontBuffers)
 
     try {
       await fs.writeFile(saveAs, pngBuffer, 'binary')
@@ -187,6 +193,11 @@ async function renderSVGAndSavePNG(
       )
 
       throw err
+    }
+
+    return {
+      width,
+      height,
     }
   }
   catch (err) {

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -87,10 +87,10 @@ async function renderSVGAndRewriteHTML(
     .use(RehypeParse, { fragment: true })
     .parse(html)
 
-  let hasOgImage = false
+  let hasOgImage: string | false = false
   visit(parsedHtml, 'element', (node) => {
-    if (node.tagName === 'meta' && node.properties?.name === 'og:image')
-      hasOgImage = true
+    if (node.tagName === 'meta' && (node.properties?.name === 'og:image' || node.properties?.name === 'twitter:image'))
+      hasOgImage = node.properties.name
     else
       return true
   })
@@ -99,7 +99,7 @@ async function renderSVGAndRewriteHTML(
     return {
       filePath: file,
       status: 'skipped',
-      reason: 'already has og:image meta tag',
+      reason: `already has ${hasOgImage} meta tag`,
     }
   }
 

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -138,7 +138,12 @@ async function renderSVGAndRewriteHTML(
       og: true,
       twitter: true,
       image: {
-        url: `${domain}/${relative(siteConfig.outDir, ogImageFilePathFullName).replaceAll(sep, '/')}`,
+        url: `${domain}/${
+          relative(siteConfig.outDir, ogImageFilePathFullName)
+            .split(sep)
+            .map(item => encodeURIComponent(item))
+            .join('/')
+        }`,
         width,
         height,
       },

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -20,7 +20,10 @@ import { initFontBuffer, initSVGRenderer, renderSVG, templateSVG } from './utils
 
 const logModulePrefix = `${cyan(`@nolebase/vitepress-plugin-og-image`)}${gray(':')}`
 
-async function tryToLocateTemplateSVGFile(siteConfig: SiteConfig): Promise<string | undefined> {
+async function tryToLocateTemplateSVGFile(siteConfig: SiteConfig, configTemplateSvgPath?: string): Promise<string | undefined> {
+  if (configTemplateSvgPath != null)
+    return resolve(siteConfig.srcDir, configTemplateSvgPath)
+
   const templateSvgPathUnderPublicDir = resolve(siteConfig.srcDir, 'public', 'og-template.svg')
   if (await fs.pathExists(templateSvgPathUnderPublicDir))
     return templateSvgPathUnderPublicDir
@@ -210,6 +213,13 @@ export interface BuildEndGenerateOpenGraphImagesOptions {
    * Font buffers to load for rendering the template SVG
    */
   svgFontBuffers?: Buffer[]
+
+  /**
+   * Temaplte SVG file path.
+   * If not supplied, will try to locate `og-template.svg` under `public` or `assets` directory,
+   * and will fallback to a builtin template.
+   */
+  templateSvgPath?: string
 }
 
 export interface BuildEndGenerateOpenGraphImagesOptionsCategory {
@@ -370,7 +380,7 @@ export function buildEndGenerateOpenGraphImages(options: BuildEndGenerateOpenGra
   return async (siteConfig: SiteConfig) => {
     await initSVGRenderer()
 
-    const ogImageTemplateSvgPath = await tryToLocateTemplateSVGFile(siteConfig)
+    const ogImageTemplateSvgPath = await tryToLocateTemplateSVGFile(siteConfig, options.templateSvgPath)
 
     await task('rendering open graph images', async (): Promise<string | undefined> => {
       const themeConfig = siteConfig.site.themeConfig as unknown as DefaultTheme.Config

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -20,7 +20,7 @@ import { initFontBuffer, initSVGRenderer, renderSVG, templateSVG } from './utils
 const logModulePrefix = `${cyan(`@nolebase/vitepress-plugin-og-image`)}${gray(':')}`
 
 async function tryToLocateTemplateSVGFile(siteConfig: SiteConfig): Promise<string | undefined> {
-  const templateSvgPathUnderPublicDir = resolve(siteConfig.root, 'public', 'og-template.svg')
+  const templateSvgPathUnderPublicDir = resolve(siteConfig.srcDir, 'public', 'og-template.svg')
   if (await fs.pathExists(templateSvgPathUnderPublicDir))
     return templateSvgPathUnderPublicDir
 
@@ -33,7 +33,7 @@ async function tryToLocateTemplateSVGFile(siteConfig: SiteConfig): Promise<strin
 }
 
 async function tryToLocateFontFile(siteConfig: SiteConfig): Promise<string | undefined> {
-  const fontPathUnderPublicDir = resolve(siteConfig.root, 'public', 'SourceHanSansSC.otf')
+  const fontPathUnderPublicDir = resolve(siteConfig.srcDir, 'public', 'SourceHanSansSC.otf')
   if (await fs.pathExists(fontPathUnderPublicDir))
     return fontPathUnderPublicDir
 
@@ -88,7 +88,7 @@ async function renderSVGAndRewriteHTML(
       templatedOgImageSvg,
       ogImageFilePathFullName,
       ogImageTemplateSvgPath,
-      relative(siteConfig.root, file),
+      relative(siteConfig.srcDir, file),
       { fontPath: await tryToLocateFontFile(siteConfig) },
     )
   }
@@ -120,7 +120,7 @@ async function renderSVGAndRewriteHTML(
   catch (err) {
     console.error(
       `${logModulePrefix} `,
-      `${red('[ERROR] ✗')} failed to write transformed HTML on path [${relative(siteConfig.root, file)}] due to ${err}`,
+      `${red('[ERROR] ✗')} failed to write transformed HTML on path [${relative(siteConfig.srcDir, file)}] due to ${err}`,
       `\n${red((err as Error).message)}\n${gray(String((err as Error).stack))}`,
     )
     return {
@@ -370,9 +370,11 @@ export function buildEndGenerateOpenGraphImages(options: BuildEndGenerateOpenGra
           const relativeLink = item.link ?? ''
           const sourceFilePath = relativeLink.endsWith('/')
             ? `${relativeLink}index.md`
-            : `${relativeLink}.md`
+            : relativeLink.endsWith('.md')
+              ? relativeLink
+              : `${relativeLink}.md`
 
-          const sourceFileContent = fs.readFileSync(`${join(siteConfig.root, sourceFilePath)}`, 'utf-8')
+          const sourceFileContent = fs.readFileSync(`${join(siteConfig.srcDir, sourceFilePath)}`, 'utf-8')
           const { data } = GrayMatter(sourceFileContent)
           const res: PageItem = {
             ...item,

--- a/packages/vitepress-plugin-og-image/src/vitepress/index.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/index.ts
@@ -474,10 +474,14 @@ export function buildEndGenerateOpenGraphImages(options: BuildEndGenerateOpenGra
         }`.split('/index')[0]
 
         const page = pages.find((item) => {
-          if (item.link === link)
+          let itemLink = item.link
+          if (itemLink?.endsWith('.md'))
+            itemLink = itemLink.slice(0, -'.md'.length)
+
+          if (itemLink === link)
             return true
 
-          if (item.link === `${link}/`)
+          if (itemLink === `${link}/`)
             return true
 
           return false

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
@@ -1,9 +1,13 @@
 import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
+import { Buffer } from 'node:buffer'
 import { Resvg, initWasm } from '@resvg/resvg-wasm'
 
 import { removeEmoji } from '../emoji'
+import type { BuildEndGenerateOpenGraphImagesOptions } from '../../index'
 import { escape } from './escape'
+
+const imageBuffers = new Map<string, Promise<Buffer>>()
 
 export function templateSVG(siteName: string, siteDescription: string, title: string, category: string, ogTemplate: string): string {
   // Remove emoji and split lines
@@ -74,7 +78,7 @@ export async function initFontBuffer(options?: { fontPath?: string }): Promise<U
   return fontBuffer
 }
 
-export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array): Promise<Uint8Array> {
+export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']): Promise<Uint8Array> {
   try {
     const resvg = new Resvg(
       svgContent,
@@ -89,6 +93,18 @@ export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array): Pr
     )
 
     try {
+      const resolvedImages = await Promise.all(
+        resvg.imagesToResolve().map(async (url) => {
+          return {
+            url,
+            buffer: await resolveImageUrlWithCache(url, imageUrlResolver),
+          }
+        }),
+      )
+
+      for (const { url, buffer } of resolvedImages)
+        resvg.resolveImage(url, buffer)
+
       return resvg.render().asPng()
     }
     catch (err) {
@@ -98,4 +114,26 @@ export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array): Pr
   catch (err) {
     throw new Error(`Failed to initiate Resvg instance to render open graph images due to ${err}`)
   }
+}
+
+function resolveImageUrlWithCache(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']): Promise<Buffer> {
+  if (imageBuffers.has(url))
+    return imageBuffers.get(url)!
+
+  const result = resolveImageUrl(url, imageUrlResolver)
+  imageBuffers.set(url, result)
+
+  return result
+}
+
+async function resolveImageUrl(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']) {
+  if (imageUrlResolver != null) {
+    const res = await imageUrlResolver(url)
+    if (res != null)
+      return res
+  }
+
+  const res = await fetch(url)
+  const buffer = await res.arrayBuffer()
+  return Buffer.from(buffer)
 }

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
@@ -101,7 +101,11 @@ export async function renderSVG(
   fontBuffer?: Uint8Array,
   imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['svgImageUrlResolver'],
   additionalFontBuffers?: Uint8Array[],
-): Promise<Uint8Array> {
+): Promise<{
+  png: Uint8Array
+  width: number
+  height: number
+}> {
   try {
     const resvg = new Resvg(
       svgContent,
@@ -130,7 +134,13 @@ export async function renderSVG(
       for (const { url, buffer } of resolvedImages)
         resvg.resolveImage(url, buffer)
 
-      return resvg.render().asPng()
+      const res = resvg.render()
+
+      return {
+        png: res.asPng(),
+        width: res.width,
+        height: res.height,
+      }
     }
     catch (err) {
       throw new Error(`Failed to render open graph images on path due to ${err}`)

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
@@ -17,13 +17,31 @@ export function templateSVG(siteName: string, siteDescription: string, title: st
     .split('\n')
 
   // Restricted 17 words per line
-  lines.forEach((val, i) => {
-    if (val.length > 17) {
-      lines[i] = val.slice(0, 17)
-      lines[i + 1] = `${val.slice(17)}${lines[i + 1] || ''}`
+  const maxLineLength = 17
+  for (let i = 0; i < lines.length; i++) {
+    const val = lines[i].trim()
+
+    if (val.length > maxLineLength) {
+      // attempt to break at a space
+      let breakPoint = val.lastIndexOf(' ', maxLineLength)
+
+      // attempt to break before before a capital letter
+      if (breakPoint < 0) {
+        for (let j = Math.min(val.length - 1, maxLineLength); j > 0; j--) {
+          if (val[j] === val[j].toUpperCase()) {
+            breakPoint = j
+            break
+          }
+        }
+      }
+      if (breakPoint < 0)
+        breakPoint = maxLineLength
+
+      lines[i] = val.slice(0, breakPoint)
+      lines[i + 1] = `${val.slice(lines[i].length)}${lines[i + 1] || ''}`
     }
     lines[i] = lines[i].trim()
-  })
+  }
 
   const categoryStr = category ? removeEmoji(category).trim() : ''
 

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/svg/render.ts
@@ -78,14 +78,21 @@ export async function initFontBuffer(options?: { fontPath?: string }): Promise<U
   return fontBuffer
 }
 
-export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']): Promise<Uint8Array> {
+export async function renderSVG(
+  svgContent: string,
+  fontBuffer?: Uint8Array,
+  imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['svgImageUrlResolver'],
+  additionalFontBuffers?: Uint8Array[],
+): Promise<Uint8Array> {
   try {
     const resvg = new Resvg(
       svgContent,
       {
         fitTo: { mode: 'width', value: 1200 },
         font: {
-          fontBuffers: fontBuffer ? [fontBuffer] : [],
+          fontBuffers: fontBuffer
+            ? [fontBuffer, ...(additionalFontBuffers ?? [])]
+            : (additionalFontBuffers ?? []),
           // Load system fonts might cost more time
           loadSystemFonts: false,
         },
@@ -116,7 +123,7 @@ export async function renderSVG(svgContent: string, fontBuffer?: Uint8Array, ima
   }
 }
 
-function resolveImageUrlWithCache(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']): Promise<Buffer> {
+function resolveImageUrlWithCache(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['svgImageUrlResolver']): Promise<Buffer> {
   if (imageBuffers.has(url))
     return imageBuffers.get(url)!
 
@@ -126,7 +133,7 @@ function resolveImageUrlWithCache(url: string, imageUrlResolver?: BuildEndGenera
   return result
 }
 
-async function resolveImageUrl(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['imageUrlResolver']) {
+async function resolveImageUrl(url: string, imageUrlResolver?: BuildEndGenerateOpenGraphImagesOptions['svgImageUrlResolver']) {
   if (imageUrlResolver != null) {
     const res = await imageUrlResolver(url)
     if (res != null)

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
@@ -73,18 +73,20 @@ export function flattenSidebar(sidebar: DefaultTheme.SidebarItem[], base?: strin
     if (curr.items) {
       return prev.concat(
         flattenSidebar(
-          curr.items
-            .map(item => addBaseToItem(item, curr.base ?? base))
-            .concat(
-              curr.link == null
-                ? []
-                : [{
-                    ...curr,
-                    items: undefined,
-                  }],
-            ),
+          curr.items.map(item => addBaseToItem(item, curr.base ?? base)),
           curr.base ?? base,
-        ),
+        )
+          .concat(
+            curr.link == null
+              ? []
+              : [{
+                  ...curr,
+                  items: undefined,
+                  link: curr.link != null
+                    ? ((curr.base ?? '') + curr.link)
+                    : curr.link,
+                }],
+          ),
       )
     }
 

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
@@ -68,11 +68,29 @@ function flattenThemeConfigSidebar(sidebar?: DefaultTheme.Sidebar): DefaultTheme
   }, [] as DefaultTheme.SidebarItem[])
 }
 
-export function flattenSidebar(sidebar: DefaultTheme.SidebarItem[]): DefaultTheme.SidebarItem[] {
+export function flattenSidebar(sidebar: DefaultTheme.SidebarItem[], base?: string): DefaultTheme.SidebarItem[] {
   return sidebar.reduce((prev, curr) => {
-    if (curr.items)
-      return prev.concat(flattenSidebar(curr.items))
+    if (curr.items) {
+      return prev.concat(
+        flattenSidebar(
+          curr.items.map(item => addBaseToItem(item, curr.base ?? base)),
+          curr.base ?? base,
+        ),
+      )
+    }
 
     return prev.concat(curr)
   }, [] as DefaultTheme.SidebarItem[])
+}
+
+function addBaseToItem(item: DefaultTheme.SidebarItem, base?: string) {
+  if (base == null || base === '')
+    return item
+
+  return {
+    ...item,
+    link: item.link != null
+      ? (base + item.link)
+      : item.link,
+  }
 }

--- a/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/utils/vitepress/sidebar.ts
@@ -73,7 +73,16 @@ export function flattenSidebar(sidebar: DefaultTheme.SidebarItem[], base?: strin
     if (curr.items) {
       return prev.concat(
         flattenSidebar(
-          curr.items.map(item => addBaseToItem(item, curr.base ?? base)),
+          curr.items
+            .map(item => addBaseToItem(item, curr.base ?? base))
+            .concat(
+              curr.link == null
+                ? []
+                : [{
+                    ...curr,
+                    items: undefined,
+                  }],
+            ),
           curr.base ?? base,
         ),
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,6 +572,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       vitepress:
         specifier: ^1.2.3
         version: 1.2.3(@algolia/client-search@4.22.1)(@types/node@20.14.8)(less@4.2.0)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.5.2)


### PR DESCRIPTION
I've made some changes to the `@nolebase/vitepress-plugin-og-image` package to improve its stability and add missing features that I needed in my project.

* Fixed an issue where documents from the sidebar were not resolved like how Vitepress resolves them
* Added support for rendering images inside the SVG template
* Added support for passing custom font buffers
* Added configuration option to specify a custom SVG template path
* Improved the line splitting algorithms to attempt to split by spaces or capital letters (useful for camelCase text)
* Made sure that an `og:image` meta tag is not added if it already exists in the HTML