### PR TITLE
feat(i18n): add Russian locales to `git-changelog` and `enhanced-readabilities`

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -65,4 +65,4 @@ words:
   - vitepress
   - vueuse
 ignoreWords: []
-import: []
+import: ["@cspell/dict-ru_ru/cspell-ext.json"]

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
   "workspaces": [
     "packages/*",
     "docs"
-  ]
+  ],
+  "dependencies": {
+    "@cspell/dict-ru_ru": "^2.2.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^2.21.1",
     "@antfu/ni": "^0.21.12",
+    "@cspell/dict-ru_ru": "^2.2.1",
     "@types/node": "^20.14.8",
     "@unocss/cli": "^0.59.4",
     "@unocss/eslint-config": "^0.58.9",
@@ -65,8 +66,5 @@
   "workspaces": [
     "packages/*",
     "docs"
-  ],
-  "dependencies": {
-    "@cspell/dict-ru_ru": "^2.2.1"
-  }
+  ]
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/locales.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/locales.ts
@@ -1,18 +1,18 @@
-import { defaultEnLocale, defaultZhCNLocale, defaultRuLocale } from '../locales'
+import { defaultEnLocale, defaultRuLocale, defaultZhCNLocale } from '../locales'
 import type { Locale } from './types'
 
 export {
   defaultEnLocale,
-  defaultZhCNLocale,
   defaultRuLocale,
+  defaultZhCNLocale,
 }
 
 export const defaultLocales: Record<string, Locale> = {
-  'zh-CN': defaultZhCNLocale,
-  'zh-Hans': defaultZhCNLocale,
-  'zh': defaultZhCNLocale,
   'en-US': defaultEnLocale,
   'en': defaultEnLocale,
   'ru-RU': defaultRuLocale,
   'ru': defaultRuLocale,
+  'zh-CN': defaultZhCNLocale,
+  'zh-Hans': defaultZhCNLocale,
+  'zh': defaultZhCNLocale,
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/locales.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/locales.ts
@@ -1,9 +1,10 @@
-import { defaultEnLocale, defaultZhCNLocale } from '../locales'
+import { defaultEnLocale, defaultZhCNLocale, defaultRuLocale } from '../locales'
 import type { Locale } from './types'
 
 export {
   defaultEnLocale,
   defaultZhCNLocale,
+  defaultRuLocale,
 }
 
 export const defaultLocales: Record<string, Locale> = {
@@ -12,4 +13,6 @@ export const defaultLocales: Record<string, Locale> = {
   'zh': defaultZhCNLocale,
   'en-US': defaultEnLocale,
   'en': defaultEnLocale,
+  'ru-RU': defaultRuLocale,
+  'ru': defaultRuLocale,
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/locales/index.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/locales/index.ts
@@ -1,7 +1,9 @@
 import defaultEnLocale from './en.yaml'
 import defaultZhCNLocale from './zh-CN.yaml'
+import defaultRuLocale from './ru-RU.yaml'
 
 export {
   defaultEnLocale,
   defaultZhCNLocale,
+  defaultRuLocale
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/locales/index.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/locales/index.ts
@@ -5,5 +5,5 @@ import defaultRuLocale from './ru-RU.yaml'
 export {
   defaultEnLocale,
   defaultZhCNLocale,
-  defaultRuLocale
+  defaultRuLocale,
 }

--- a/packages/vitepress-plugin-enhanced-readabilities/src/locales/ru-RU.yaml
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/locales/ru-RU.yaml
@@ -1,0 +1,68 @@
+title:
+  title: Повышенная читаемость
+  titleAriaLabel: Повышенная читаемость
+layoutSwitch:
+  title: Макет страницы
+  titleHelpMessage: >-
+   Измените стиль оформления документации, выберите максимально удобный вариант в зависимости от размера вашего экрана и типа устройства.
+  titleAriaLabel: Макет страницы
+  titleScreenNavWarningMessage: Изменение макета страницы недоступено на экранах мобильных устройств
+  optionFullWidth: Развёрнутый
+  optionFullWidthAriaLabel: Развёрнутый
+  optionFullWidthHelpMessage: Страница и область содержимого занимают всю ширину экрана.
+  optionSidebarWidthAdjustableOnly: Настраиваемая ширина страницы
+  optionSidebarWidthAdjustableOnlyAriaLabel: Настраиваемая ширина страницы
+  optionSidebarWidthAdjustableOnlyHelpMessage: >-
+    Управление максимальной шириной страницы, область содержимого будет зафиксирована.
+  optionBothWidthAdjustable: Полностью настраиваемый
+  optionBothWidthAdjustableAriaLabel: Полностью настраиваемый
+  optionBothWidthAdjustableHelpMessage: >-
+    Управление максимальной шириной страницы и содержимого.
+  optionOriginalWidth: Оригинальная ширина
+  optionOriginalWidthAriaLabel: Оригинальная ширина
+  optionOriginalWidthHelpMessage: Ширина страницы, предусмотренная разработчиками VitePress.
+  contentLayoutMaxWidth:
+    title: Максимальная ширина страницы
+    titleAriaLabel: Максимальная ширина страницы
+    titleHelpMessage: >-
+      Точное значение ширины страницы можно настроить для различных экранов и адаптировать условиям чтения.
+    titleScreenNavWarningMessage: Изменение максимальной ширины страницы недоступно на экранах мобильных устройств.
+    slider: Регулеровка максимальной ширины страницы
+    sliderAriaLabel: Регулеровка максимальной ширины страницы
+    sliderHelpMessage: >-
+      Ползунок, позволяющий настроить максимальную ширину страницы. Может быть изменён в зависимости от размера экрана.
+  pageLayoutMaxWidth:
+    title: Максимальная ширина содержимого
+    titleAriaLabel: Максимальная ширина содержимого
+    titleHelpMessage: >-
+      Точное значение ширины содержимого можно настроить для различных экранов и адаптировать условиям чтения.
+    titleScreenNavWarningMessage: Изменение максимальной ширины страницы недоступно на экранах мобильных устройств.
+    slider: Регулеровка максимальной ширины содержимого
+    sliderAriaLabel: Регулеровка максимальной ширины содержимого
+    sliderHelpMessage: >-
+      Ползунок, позволяющий настроить максимальную ширину содержимого. Может быть изменён в зависимости от размера экрана.
+spotlight:
+  title: Подсветка
+  titleAriaLabel: Подсветка
+  titleHelpMessage: >-
+    Выделите блок содержимого, на котором находится курсор.
+  titleScreenNavWarningMessage: Подсветка недоступна на экране мобильного устройства.
+  optionOn: 'Включить'
+  optionOnAriaLabel: 'Включить'
+  optionOnHelpMessage: Включите подсветку.
+  optionOff: 'Выключить'
+  optionOffAriaLabel: 'Выключить'
+  optionOffHelpMessage: Выключите подсветку.
+  styles:
+    title: Стиль подсветки
+    titleAriaLabel: Стиль подсветки
+    titleHelpMessage: Измените стиль выделения.
+    titleScreenNavWarningMessage: Подсветка недоступна на экране мобильного устройства.
+    optionUnder: Под блоком
+    optionUnderAriaLabel: Под блоком
+    optionUnderHelpMessage: >-
+      Добавляет сплошную заливку блока под курсором.
+    optionAside: Сбоку от блока
+    optionAsideAriaLabel: Сбоку от блока
+    optionAsideHelpMessage: >-
+      Добавляет фиксированную сплошную линию рядом с блоком под курсором

--- a/packages/vitepress-plugin-git-changelog/src/client/locales.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/locales.ts
@@ -1,18 +1,18 @@
-import { defaultEnLocale, defaultZhCNLocale, defaultRuLocale } from '../locales'
+import { defaultEnLocale, defaultRuLocale, defaultZhCNLocale } from '../locales'
 import type { Locale } from './types'
 
 export {
   defaultEnLocale,
-  defaultZhCNLocale,
   defaultRuLocale,
+  defaultZhCNLocale,
 }
 
 export const defaultLocales: Record<string, Locale> = {
-  'zh-CN': defaultZhCNLocale,
-  'zh-Hans': defaultZhCNLocale,
-  'zh': defaultZhCNLocale,
   'en-US': defaultEnLocale,
   'en': defaultEnLocale,
   'ru-RU': defaultRuLocale,
   'ru': defaultRuLocale,
+  'zh-CN': defaultZhCNLocale,
+  'zh-Hans': defaultZhCNLocale,
+  'zh': defaultZhCNLocale,
 }

--- a/packages/vitepress-plugin-git-changelog/src/client/locales.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/locales.ts
@@ -1,9 +1,10 @@
-import { defaultEnLocale, defaultZhCNLocale } from '../locales'
+import { defaultEnLocale, defaultZhCNLocale, defaultRuLocale } from '../locales'
 import type { Locale } from './types'
 
 export {
   defaultEnLocale,
   defaultZhCNLocale,
+  defaultRuLocale,
 }
 
 export const defaultLocales: Record<string, Locale> = {
@@ -12,4 +13,6 @@ export const defaultLocales: Record<string, Locale> = {
   'zh': defaultZhCNLocale,
   'en-US': defaultEnLocale,
   'en': defaultEnLocale,
+  'ru-RU': defaultRuLocale,
+  'ru': defaultRuLocale,
 }

--- a/packages/vitepress-plugin-git-changelog/src/locales/index.ts
+++ b/packages/vitepress-plugin-git-changelog/src/locales/index.ts
@@ -1,7 +1,9 @@
 import defaultEnLocale from './en.yaml'
 import defaultZhCNLocale from './zh-CN.yaml'
+import defaultRuLocale from './ru-RU.yaml'
 
 export {
   defaultEnLocale,
   defaultZhCNLocale,
+  defaultRuLocale
 }

--- a/packages/vitepress-plugin-git-changelog/src/locales/index.ts
+++ b/packages/vitepress-plugin-git-changelog/src/locales/index.ts
@@ -4,6 +4,6 @@ import defaultRuLocale from './ru-RU.yaml'
 
 export {
   defaultEnLocale,
+  defaultRuLocale,
   defaultZhCNLocale,
-  defaultRuLocale
 }

--- a/packages/vitepress-plugin-git-changelog/src/locales/ru-RU.yaml
+++ b/packages/vitepress-plugin-git-changelog/src/locales/ru-RU.yaml
@@ -1,0 +1,12 @@
+changelog:
+  title: 'История изменений'
+  titleId: 'история изменений'
+  noData: 'Нет изменений'
+  lastEdited: 'Последнее редактирование {{daysAgo}}'
+  lastEditedDateFnsLocaleName: 'ru'
+  viewFullHistory: 'Показать историю'
+  committedOn: ' от {{date}}'
+contributors:
+  title: 'Авторы'
+  titleId: 'авторы'
+  noData: 'Нет информации'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@cspell/dict-ru_ru':
+        specifier: ^2.2.1
+        version: 2.2.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.21.1
@@ -1050,6 +1054,9 @@ packages:
     bundledDependencies:
       - is-unicode-supported
 
+  '@cspell/dict-ru_ru@2.2.1':
+    resolution: {integrity: sha512-05pgxSNR13/zWIhGxXS/HpFmfjnorlNB6YIxOVLh82/JWqIPKYPDKUOnEQt212ohtZqoVimUOxaOR2d7wyy7og==}
+
   '@docsearch/css@3.6.0':
     resolution: {integrity: sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ==}
 
@@ -1391,6 +1398,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1398,6 +1406,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@iconify-json/carbon@1.1.36':
     resolution: {integrity: sha512-NC3VcqLtwLZpi7+LeXj+99/byv+asrnCQxiDNCZV6hKr9WcNh6C25kJguJYfN+dV54kOkw78e+6PitQi2Bppnw==}
@@ -2761,7 +2770,7 @@ packages:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@8.2.2:
     resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
@@ -3672,6 +3681,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4745,6 +4755,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.7:
@@ -5978,6 +5989,8 @@ snapshots:
       '@clack/core': 0.3.4
       picocolors: 1.0.1
       sisteransi: 1.0.5
+
+  '@cspell/dict-ru_ru@2.2.1': {}
 
   '@docsearch/css@3.6.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@cspell/dict-ru_ru':
-        specifier: ^2.2.1
-        version: 2.2.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.21.1
@@ -42,6 +38,9 @@ importers:
       '@vueuse/core':
         specifier: ^10.11.0
         version: 10.11.0(vue@3.4.30(typescript@5.5.2))
+      '@cspell/dict-ru_ru':
+        specifier: ^2.2.1
+        version: 2.2.1
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2


### PR DESCRIPTION
Hello. We'd like to help translate plugins and documentation into our team's native language, and it might be useful for other authors as well.

As a start and for evaluation - I and @X1Z53 have added builtin localizations for `git-changelog` and `enhanced-readabilities`.

If you have any feedback or see any issues - we'd love to hear from you.