### PR TITLE
feat(git-changelog): add authors for specific page

### DIFF
--- a/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -329,6 +329,24 @@ interface Locale {
 
 The Git-based page histories plugin provides accessibility support by default. You can override accessible labels (aria-label) via [Configuration](#configuration) in the same way as [Internationalization](#internationalization), see [Locales Options](#locales-options) for a description of what labels can be configured for accessibility.
 
+## Adding Contributors for Specific Pages
+
+In certain situations, Git records may miss some contributors. To address this issue, we provide a Front Matter key that allows you to supplement author information for specific pages.
+
+You can add missing contributor information in the Front Matter of the Markdown file using the following format:
+
+```md
+---
+authors: ['author1', 'author2']
+---
+
+<!-- body -->
+```
+
+These contributors will be merged with the authors retrieved from Git.
+
+Please note that the contributors specified here will not go through the `mapAuthorsByNameAlias` data mapping of the [Vite plugin `mapAuthors` option](./configure-vite-plugins.md#option-mapauthors-map-contributors-information). Therefore, you need to use the `name` attribute values from the `mapAuthors` array for each author. Otherwise, the contributor will be considered an independent author.
+
 ## More customizations?
 
 It is possible though.

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -1,3 +1,7 @@
+---
+authors: ['northword1']
+---
+
 # 配置 UI 组件
 
 ::: danger 弃用 UI 组件选项的 `mapAuthors` 字段
@@ -328,6 +332,24 @@ interface Locale {
 ## 无障碍
 
 基于 Git 的页面历史插件默认提供了无障碍的支持，你可以通过 [配置](#配置选项) 来对无障碍的文案进行复写，使用方法和 [国际化](#国际化) 一样，有关无障碍有哪些文案可以配置，请参阅 [国际化字段选项](#国际化字段选项)。
+
+## 为特定页面增补贡献者
+
+在某些情况下，Git 记录中可能会遗漏部分贡献者信息。为了解决这个问题，我们提供了一个 Front Matter 键，允许你为特定页面补充作者信息。
+
+你可以在 Markdown 文件的 Front Matter 中添加缺失的贡献者信息，格式如下：
+
+```md
+---
+authors: ['author1', 'author2']
+---
+
+<!-- body-->
+```
+
+这些贡献者信息将会与从 Git 中获取到的作者信息合并显示。
+
+主要注意的是，此处指定的贡献者将不会经过 [Vite 插件 `mapAuthors` 选项](./configure-vite-plugins.md#选项-mapcontributors-为贡献者添加数据映射) 的 `mapAuthorsByNameAlias` 数据映射，因此你需要填写 `mapAuthors` 数组中每个作者信息 `name` 属性的值，否则，该贡献者将视为一个独立的作者。
 
 ## 更多自定义能力？
 

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -1,7 +1,3 @@
----
-authors: ['northword1']
----
-
 # 配置 UI 组件
 
 ::: danger 弃用 UI 组件选项的 `mapAuthors` 字段

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
@@ -48,7 +48,7 @@ export function useChangelog(pageData: Ref<PageData>) {
       })
 
     return Array.from(uniq.values())
-      .sort((a, b) => a.commitsCount - b.commitsCount)
+      .sort((a, b) => b.commitsCount - a.commitsCount)
       .map((a) => {
         return {
           ...a,

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
@@ -29,9 +29,9 @@ export function useChangelog(pageData: Ref<PageData>) {
   })
 
   const authors = computed(() => {
-    const uniq = new Map<string, AuthorInfo>()
+    const uniq = new Map<string, AuthorInfo>();
 
-    commits.value.map(c => c.authors)
+    [...commits.value.map(c => c.authors), ...pageData.value.frontmatter.authors ?? []]
       .flat()
       .map((name) => {
         if (!uniq.has(name)) {
@@ -52,8 +52,10 @@ export function useChangelog(pageData: Ref<PageData>) {
       .map((a) => {
         return {
           ...a,
-          ...gitChangelog.value.authors.find(item => item.name === a.name),
-
+          ...gitChangelog.value.authors.find(item => item.name === a.name) ?? {
+            // a avatarUrl fallback for authors in frontmatter
+            avatarUrl: `https://gravatar.com/avatar/${a.name}?d=retro`,
+          },
         }
       })
   })

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
@@ -3,6 +3,7 @@ import { type Ref, computed, ref, toValue } from 'vue'
 import type { PageData } from 'vitepress'
 import changelog from 'virtual:nolebase-git-changelog'
 import type { Changelog, Commit, CommitAuthor } from '../../types'
+import { isStringArray } from '../utils'
 
 export interface AuthorInfo extends CommitAuthor {
   commitsCount: number
@@ -29,9 +30,13 @@ export function useChangelog(pageData: Ref<PageData>) {
   })
 
   const authors = computed(() => {
-    const uniq = new Map<string, AuthorInfo>();
+    const uniq = new Map<string, AuthorInfo>()
 
-    [...commits.value.map(c => c.authors), ...pageData.value.frontmatter.authors ?? []]
+    const authorsFromFrontMatter: string[] = isStringArray(pageData.value.frontmatter.authors)
+      ? pageData.value.frontmatter.authors
+      : [];
+
+    [...commits.value.map(c => c.authors), ...authorsFromFrontMatter]
       .flat()
       .map((name) => {
         if (!uniq.has(name)) {

--- a/packages/vitepress-plugin-git-changelog/src/client/utils.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/utils.ts
@@ -38,6 +38,10 @@ export function formatDistanceToNowFromValue(value: Date, localeName = 'enUS') {
   }
 }
 
+export function isStringArray(value: any): value is string[] {
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+}
+
 /**
  * Hashes a string using SHA-256
  *


### PR DESCRIPTION
closes: #259

- [x] Fixed contributor list sorting bug introduced by #269
- [x] Allow users to add contributors to specific pages

The format and scheme mentioned in #259 was not used because it conflicted with some of the ideas in #269.
