### PR TITLE
fix(git-changelog): layout of commit inline authors and hmr bugs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -299,7 +299,6 @@ export default defineConfig({
       },
     },
   },
-  lastUpdated: true,
   cleanUrls: true,
   ignoreDeadLinks: [
     // Site Config | VitePress
@@ -314,6 +313,8 @@ export default defineConfig({
     ['script', { 'defer': 'true', 'data-domain': 'nolebase-integrations.ayaka.io', 'data-api': '/api/v1/page-external-data/submit', 'src': '/assets/page-external-data/js/script.js' }],
   ],
   themeConfig: {
+    // Only enable this on debug component style
+    // externalLinkIcon: true,
     outline: 'deep',
     socialLinks: [
       { icon: 'github', link: 'https://github.com/nolebase/integrations' },

--- a/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -86,56 +86,7 @@ We have changed the structure of locales config since `2.0.0`, and the old struc
 ::: details Complete configurable options
 
 ```typescript twoslash
-interface SocialEntry {
-  type: 'github' | 'twitter' | 'email' | string
-  icon: string
-  link: string
-}
-
-interface Locale extends Record<string, any> {
-  /**
-   * The changelog section configuration
-   */
-  changelog?: {
-    /**
-     * The title of the changelog section
-     */
-    title?: string
-    /**
-     * What to display when there are no logs
-     */
-    noData?: string
-    /**
-     * What to display when the page was last edited
-     */
-    lastEdited?: string
-    /**
-     * The name of the locale to use for date-fns
-     */
-    lastEditedDateFnsLocaleName?: string
-    /**
-     * What to display when the user wants to view the full history
-     */
-    viewFullHistory?: string
-    /**
-     * What to display when the commit was committed
-     */
-    committedOn?: string
-  }
-  /**
-   * The contributors section configuration
-   */
-  contributors?: {
-    /**
-     * The title of the contributors section
-     */
-    title?: string
-    /**
-     * What to display when there are no contributors
-     */
-    noData?: string
-  }
-}
+import type { Locale } from '@nolebase/vitepress-plugin-git-changelog/client'
 // ---cut---
 /**
  * Options
@@ -202,6 +153,10 @@ export interface Options {
    * Whether to hide the sort by button
    */
   hideSortBy?: boolean
+  /**
+   *  Whether to display authors of commits right inside of commit line
+   */
+  displayAuthorsInsideCommitLine?: boolean
 }
 ```
 

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -86,56 +86,7 @@ export const Theme: ThemeConfig = {
 ::: details 完整的可以配置的选项
 
 ```typescript twoslash
-interface SocialEntry {
-  type: 'github' | 'twitter' | 'email' | string
-  icon: string
-  link: string
-}
-
-interface Locale extends Record<string, any> {
-  /**
-   * The changelog section configuration
-   */
-  changelog?: {
-    /**
-     * The title of the changelog section
-     */
-    title?: string
-    /**
-     * What to display when there are no logs
-     */
-    noData?: string
-    /**
-     * What to display when the page was last edited
-     */
-    lastEdited?: string
-    /**
-     * The name of the locale to use for date-fns
-     */
-    lastEditedDateFnsLocaleName?: string
-    /**
-     * What to display when the user wants to view the full history
-     */
-    viewFullHistory?: string
-    /**
-     * What to display when the commit was committed
-     */
-    committedOn?: string
-  }
-  /**
-   * The contributors section configuration
-   */
-  contributors?: {
-    /**
-     * The title of the contributors section
-     */
-    title?: string
-    /**
-     * What to display when there are no contributors
-     */
-    noData?: string
-  }
-}
+import type { Locale } from '@nolebase/vitepress-plugin-git-changelog/client'
 // ---cut---
 /**
  * Options
@@ -202,6 +153,10 @@ export interface Options {
    * Whether to hide the sort by button
    */
   hideSortBy?: boolean
+  /**
+   *  Whether to display authors of commits right inside of commit line
+   */
+  displayAuthorsInsideCommitLine?: boolean
 }
 ```
 

--- a/packages/vitepress-plugin-git-changelog/build.config.ts
+++ b/packages/vitepress-plugin-git-changelog/build.config.ts
@@ -26,7 +26,6 @@ export default defineBuildConfig({
     { builder: 'mkdist', input: './src/types', outDir: './dist/types', loaders: ['js'] },
     { builder: 'rollup', input: './src/locales/index', outDir: './dist/locales' },
     { builder: 'rollup', input: './src/vite/index', outDir: './dist/vite' },
-    { builder: 'rollup', input: './src/vite/index', outDir: './dist/vite' },
   ],
   clean: true,
   sourcemap: true,

--- a/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
@@ -19,8 +19,8 @@ import CommitTagLine from './CommitTagLine.vue'
 const options = defu(inject(InjectionKey, {}), defaultOptions)
 
 const { t } = useI18n()
-const { lang, page } = useData()
-const { commits, useHmr } = useChangelog(page)
+const { lang } = useData()
+const { commits, useHmr } = useChangelog()
 
 // The order of commits, defaults to true (descending order)
 const isDescending = ref(true)

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
@@ -42,7 +42,7 @@ function formatCommittedOn(timestamp: number): string {
 
 <template>
   <div class="i-octicon:git-commit-16 m-auto rotate-90 transform op-30" />
-  <div flex gap-1>
+  <div flex gap-1 align-baseline>
     <a :href="props.commit.hash_url || `${props.commit.repo_url}/commit/${props.commit.hash}`" target="_blank">
       <code
         class="text-xs text-$vp-c-brand-1 hover:text-$vp-c-brand-1"
@@ -55,7 +55,7 @@ function formatCommittedOn(timestamp: number): string {
     <span>-</span>
     <span>
       <span class="text-sm <sm:text-xs" v-html="renderCommitMessage(commit.repo_url || 'https://github.com/example/example', commit.message)" />
-      <div v-if="options.displayAuthorsInsideCommitLine" class="my-1 ml-1 flex items-center gap-1">
+      <span v-if="options.displayAuthorsInsideCommitLine" class="my-1 ml-3 gap-1">
         <template
           v-for="a of commit.authors"
           :key="a.name"
@@ -64,17 +64,12 @@ function formatCommittedOn(timestamp: number): string {
             v-if="(typeof a.url !== 'undefined')"
             :href="a.url"
           >
-            <img :src="a.avatarUrl" :alt="`The avatar of contributor named as ${a.name}`" class="vp-nolebase-git-changelog-commit-avatar h-6 w-6 rounded-full">
+            <img :src="a.avatarUrl" :alt="`The avatar of contributor named as ${a.name}`" class="vp-nolebase-git-changelog-commit-avatar inline-block h-6 w-6 rounded-full v-middle">
           </a>
-          <img v-else :src="a.avatarUrl" :alt="`The avatar of contributor named as ${a.name}`" class="vp-nolebase-git-changelog-commit-avatar h-6 w-6 rounded-full">
+          <img v-else :src="a.avatarUrl" :alt="`The avatar of contributor named as ${a.name}`" class="vp-nolebase-git-changelog-commit-avatar inline-block h-6 w-6 rounded-full v-middle">
         </template>
-        <ClientOnly>
-          <span class="text-xs op-50" :title="toDate(commit.date_timestamp).toString()">
-            {{ formatCommittedOn(commit.date_timestamp) }}
-          </span>
-        </ClientOnly>
-      </div>
-      <ClientOnly v-else>
+      </span>
+      <ClientOnly>
         <span class="text-xs op-50" :title="toDate(commit.date_timestamp).toString()">
           {{ formatCommittedOn(commit.date_timestamp) }}
         </span>
@@ -87,9 +82,5 @@ function formatCommittedOn(timestamp: number): string {
 .vp-nolebase-git-changelog-commit-avatar {
   border: 2px solid var(--vp-c-bg-soft);
   margin-left: -0.5em;
-  max-width: none;
-}
-.vp-nolebase-git-changelog-commit-avatar :first-child{
-  margin-left: 0;
 }
 </style>

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
 const options = defu(inject(InjectionKey, {}), defaultOptions)
 
 const { t } = useI18n()
-const { lang, page } = useData()
+const { lang } = useData()
 
 const locale = computed<Locale>(() => {
   if (!options.locales || typeof options.locales === 'undefined')
@@ -30,7 +30,7 @@ const locale = computed<Locale>(() => {
 
 const authors = ref<AuthorInfo[]>([])
 if (options.displayAuthorsInsideCommitLine) {
-  const { getAuthorsForOneCommit } = useChangelog(page)
+  const { getAuthorsForOneCommit } = useChangelog()
   authors.value = getAuthorsForOneCommit(props.commit)
 }
 

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
@@ -43,7 +43,7 @@ function formatCommittedOn(timestamp: number): string {
 <template>
   <div class="i-octicon:git-commit-16 m-auto rotate-90 transform op-30" />
   <div flex gap-1 align-baseline>
-    <a :href="props.commit.hash_url || `${props.commit.repo_url}/commit/${props.commit.hash}`" target="_blank">
+    <a :href="props.commit.hash_url || `${props.commit.repo_url}/commit/${props.commit.hash}`" target="_blank" class="no-icon">
       <code
         class="text-xs text-$vp-c-brand-1 hover:text-$vp-c-brand-1"
         transition="color ease-in-out"
@@ -63,6 +63,7 @@ function formatCommittedOn(timestamp: number): string {
           <a
             v-if="(typeof a.url !== 'undefined')"
             :href="a.url"
+            class="no-icon"
           >
             <img :src="a.avatarUrl" :alt="`The avatar of contributor named as ${a.name}`" class="vp-nolebase-git-changelog-commit-avatar inline-block h-6 w-6 rounded-full v-middle">
           </a>

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitRegularLine.vue
@@ -1,19 +1,18 @@
 <script setup lang="ts">
-import { computed, inject, ref } from 'vue'
+import { computed, inject } from 'vue'
 import { toDate } from 'date-fns'
 import { useData } from 'vitepress'
 import { defu } from 'defu'
 
 import { useI18n } from '../composables/i18n'
 import type { Locale } from '../types'
-import type { Commit } from '../../types'
 import { formatDistanceToNowFromValue, renderCommitMessage } from '../utils'
 import { defaultEnLocale, defaultLocales } from '../locales'
 import { InjectionKey, defaultNumCommitHashLetters, defaultOptions } from '../constants'
-import { type AuthorInfo, useChangelog } from '../composables/changelog'
+import type { CommitWithAuthorInfo } from '../composables/changelog'
 
 const props = defineProps<{
-  commit: Commit
+  commit: CommitWithAuthorInfo
 }>()
 
 const options = defu(inject(InjectionKey, {}), defaultOptions)
@@ -27,12 +26,6 @@ const locale = computed<Locale>(() => {
 
   return options.locales[lang.value] || defaultEnLocale || {}
 })
-
-const authors = ref<AuthorInfo[]>([])
-if (options.displayAuthorsInsideCommitLine) {
-  const { getAuthorsForOneCommit } = useChangelog()
-  authors.value = getAuthorsForOneCommit(props.commit)
-}
 
 function formatCommittedOn(timestamp: number): string {
   const date = toDate(timestamp)
@@ -64,7 +57,7 @@ function formatCommittedOn(timestamp: number): string {
       <span class="text-sm <sm:text-xs" v-html="renderCommitMessage(commit.repo_url || 'https://github.com/example/example', commit.message)" />
       <div v-if="options.displayAuthorsInsideCommitLine" class="my-1 ml-1 flex items-center gap-1">
         <template
-          v-for="a of authors"
+          v-for="a of commit.authors"
           :key="a.name"
         >
           <a

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitTagLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitTagLine.vue
@@ -44,7 +44,7 @@ function formatCommittedOn(timestamp: number): string {
     <div class="i-octicon:rocket-16 !h-[50%] !min-h-[50%] !min-w-[50%] !w-[50%]" m="auto" />
   </div>
   <div flex items-center gap-1>
-    <a v-if="props.commit.tags && props.commit.tags.length === 1" :href="props.commit.release_tag_url" target="_blank">
+    <a v-if="props.commit.tags && props.commit.tags.length === 1" :href="props.commit.release_tag_url" target="_blank" class="no-icon">
       <code class="font-bold">{{ props.commit.tag }}</code>
     </a>
     <span v-else>

--- a/packages/vitepress-plugin-git-changelog/src/client/components/CommitTagLine.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/CommitTagLine.vue
@@ -5,14 +5,14 @@ import { useData } from 'vitepress'
 import { defu } from 'defu'
 
 import type { Locale } from '../types'
-import type { Commit } from '../../types'
+import type { CommitWithAuthorInfo } from '../composables/changelog'
 import { useI18n } from '../composables/i18n'
 import { formatDistanceToNowFromValue } from '../utils'
 import { defaultEnLocale, defaultLocales } from '../locales'
 import { InjectionKey, defaultOptions } from '../constants'
 
 const props = defineProps<{
-  commit: Commit
+  commit: CommitWithAuthorInfo
 }>()
 
 const options = defu(inject(InjectionKey, {}), defaultOptions)

--- a/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { inject, onMounted } from 'vue'
-import { useData } from 'vitepress'
 import { defu } from 'defu'
 
 import { useChangelog } from '../composables/changelog'
@@ -10,8 +9,7 @@ import { InjectionKey, defaultOptions } from '../constants'
 const options = defu(inject(InjectionKey, {}), defaultOptions)
 
 const { t } = useI18n()
-const { page } = useData()
-const { authors, useHmr } = useChangelog(page)
+const { authors, useHmr } = useChangelog()
 
 onMounted(() => {
   useHmr()

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
@@ -83,12 +83,6 @@ export function useChangelog() {
     })
   })
 
-  const getAuthorsForOneCommit = (commit: Commit): AuthorInfo[] => {
-    return commit.authors.map((name) => {
-      return authors.value.find(a => a.name === name)
-    }).filter(v => !!v)
-  }
-
   const update = (data: Changelog) => {
     gitChangelog.value = data
   }
@@ -131,6 +125,5 @@ export function useChangelog() {
     commits,
     authors,
     useHmr,
-    getAuthorsForOneCommit,
   }
 }

--- a/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/composables/changelog.ts
@@ -1,6 +1,7 @@
-import { type Ref, computed, ref, toValue } from 'vue'
+import { computed, ref, toValue } from 'vue'
 
-import type { PageData } from 'vitepress'
+import { useData } from 'vitepress'
+
 import changelog from 'virtual:nolebase-git-changelog'
 import type { Changelog, Commit, CommitAuthor } from '../../types'
 import { isStringArray } from '../utils'
@@ -9,13 +10,15 @@ export interface AuthorInfo extends CommitAuthor {
   commitsCount: number
 }
 
-export function useChangelog(pageData: Ref<PageData>) {
+export function useChangelog() {
+  const { page } = useData()
+
   const gitChangelog = ref<Changelog>(changelog)
   if (!gitChangelog.value)
     gitChangelog.value = { commits: [], authors: [] }
 
   const commits = computed<Commit[]>(() => {
-    const currentPath = toValue(pageData.value.filePath)
+    const currentPath = toValue(page.value.filePath)
 
     const allCommits = gitChangelog.value.commits
     // filter the commits that either have a tag, or directly equal the current path, or renamed to the current path
@@ -32,8 +35,8 @@ export function useChangelog(pageData: Ref<PageData>) {
   const authors = computed<AuthorInfo[]>(() => {
     const uniq = new Map<string, AuthorInfo>()
 
-    const authorsFromFrontMatter: string[] = isStringArray(pageData.value.frontmatter.authors)
-      ? pageData.value.frontmatter.authors
+    const authorsFromFrontMatter: string[] = isStringArray(page.value.frontmatter.authors)
+      ? page.value.frontmatter.authors
       : [];
 
     [...commits.value.map(c => c.authors), ...authorsFromFrontMatter]
@@ -79,7 +82,7 @@ export function useChangelog(pageData: Ref<PageData>) {
     if (import.meta.hot) {
       import.meta.hot.send('nolebase-git-changelog:client-mounted', {
         page: {
-          filePath: pageData.value.filePath,
+          filePath: page.value.filePath,
         },
       })
 

--- a/packages/vitepress-plugin-git-changelog/src/client/utils.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/utils.ts
@@ -14,7 +14,7 @@ export function renderMarkdown(markdownText = '') {
     .replace(/\*\*(.*)\*\*/g, '<b>$1</b>')
     .replace(/\*(.*)\*/g, '<i>$1</i>')
     .replace(/!\[(.*?)\]\((.*?)\)/g, '<img alt=\'$1\' src=\'$2\' />')
-    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href=\'$2\'>$1</a>')
+    .replace(/\[(.*?)\]\((.*?)\)/g, '<a class="no-icon" href=\'$2\'>$1</a>')
     .replace(/`(.*?)`/g, '<code>$1</code>')
     .replace(/\n$/gm, '<br />')
 
@@ -23,7 +23,7 @@ export function renderMarkdown(markdownText = '') {
 
 export function renderCommitMessage(repoLink: string, msg: string) {
   return renderMarkdown(msg)
-    .replace(/#(\d+)/g, `<a href=\'${repoLink}/issues/$1\'>#$1</a>`)
+    .replace(/#(\d+)/g, `<a class="no-icon" href=\'${repoLink}/issues/$1\'>#$1</a>`)
 }
 
 export function formatDistanceToNowFromValue(value: Date, localeName = 'enUS') {

--- a/packages/vitepress-plugin-git-changelog/src/vite/types.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/types.ts
@@ -1,4 +1,4 @@
-import type { Author } from 'src/types'
+import type { Author } from '../types'
 import type {
   CommitToStringHandler,
   CommitToStringsHandler,


### PR DESCRIPTION
- [x] Minor refactoring of useChangelog:
  - [x] get the filepath inside a composable function, no need to pass the parameter inside the component
  - [x] Returned commits with author information handled, no need to handle it further in the component.
- [x] fix the layout of commit inline authors, see below

  befor:

  ![befor](https://github.com/user-attachments/assets/a521b4a8-46bb-45c7-849f-1f9a3048e1d8)


  after:

  ![after](https://github.com/user-attachments/assets/cc09cd29-4705-41ef-b777-b44bfff709da)

- [x] Fixed changelog not displaying when starting dev (it worked after a refresh, probably because the author info was not captured initially)
- [x] Documentation for `displayAuthorsInsideCommitLine`.
- [x] Hot reloading bug: When manually refreshing a page, the changelogs and contributors on many pages become no changelogs due to not updating the cache to the client...
- [x] Hide external link icons as they break the layout:

  before:

  ![image](https://github.com/user-attachments/assets/7780e65c-6962-422c-aeb6-53a9867b437f)

  after:

  ![image](https://github.com/user-attachments/assets/426ee44a-5856-4e87-9763-dd0483d65b8e)

- [x] Disable VitePress' built-in lastUpdated, since relevant content is already provided when gitchangelog is enabled, this option is meaningless.