### PR TITLE
feat(i18n - git-changelog): add locale support for contributors

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -71,10 +71,6 @@ export default defineConfig({
         },
         {
           name: 'Rizumu',
-          i18n: {
-            'ru-RU': 'Римузу',
-            'zh-CN': 'Римузу',
-          },
           username: 'LittleSound',
           mapByNameAliases: ['Rizumu Ayaka', 'Ayaka Rizumu'],
           mapByEmailAliases: ['rizumu@ayaka.moe'],

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
         },
         {
           name: 'Rizumu',
+          i18n: {
+            'ru-RU': 'Римузу',
+            'zh-CN': 'Римузу',
+          },
           username: 'LittleSound',
           mapByNameAliases: ['Rizumu Ayaka', 'Ayaka Rizumu'],
           mapByEmailAliases: ['rizumu@ayaka.moe'],

--- a/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
@@ -12,7 +12,7 @@ const options = defu(inject(InjectionKey, {}), defaultOptions)
 const { t } = useI18n()
 const { authors, useHmr } = useChangelog()
 
-const { localeIndex } = useData()
+const { lang } = useData()
 
 onMounted(() => {
   useHmr()
@@ -49,14 +49,14 @@ onMounted(() => {
           class="no-icon flex items-center gap-2"
         >
           <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
-          {{ c.i18n ? c.i18n[localeIndex] ?? c.name : c.name }}
+          {{ c.i18n ? c.i18n[lang] ?? c.name : c.name }}
         </a>
         <div
           v-else
           class="flex items-center gap-2"
         >
           <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
-          {{ c.i18n ? c.i18n[localeIndex] ?? c.name : c.name }}
+          {{ c.i18n ? c.i18n[lang] ?? c.name : c.name }}
         </div>
       </template>
     </template>

--- a/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Contributors.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { inject, onMounted } from 'vue'
+import { useData } from 'vitepress'
 import { defu } from 'defu'
 
 import { useChangelog } from '../composables/changelog'
@@ -10,6 +11,8 @@ const options = defu(inject(InjectionKey, {}), defaultOptions)
 
 const { t } = useI18n()
 const { authors, useHmr } = useChangelog()
+
+const { localeIndex } = useData()
 
 onMounted(() => {
   useHmr()
@@ -46,14 +49,14 @@ onMounted(() => {
           class="no-icon flex items-center gap-2"
         >
           <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
-          {{ c.name }}
+          {{ c.i18n ? c.i18n[localeIndex] ?? c.name : c.name }}
         </a>
         <div
           v-else
           class="flex items-center gap-2"
         >
           <img :src="c.avatarUrl" :alt="`The avatar of contributor named as ${c.name}`" class="h-8 w-8 rounded-full">
-          {{ c.name }}
+          {{ c.i18n ? c.i18n[localeIndex] ?? c.name : c.name }}
         </div>
       </template>
     </template>

--- a/packages/vitepress-plugin-git-changelog/src/types/index.ts
+++ b/packages/vitepress-plugin-git-changelog/src/types/index.ts
@@ -95,6 +95,10 @@ export interface CommitAuthor {
    */
   name: string
   /**
+   * The author alternative names for i18n
+   */
+  i18n?: Record<string, string>
+  /**
    * The author email of the commit.
    */
   email?: string
@@ -117,9 +121,13 @@ export interface SocialEntry {
 
 export interface Contributor {
   /**
-   * The overriding display name of the contributor
+   * The overriding display name of the contributor in default locale
    */
   name?: string
+  /**
+   * The overriding display name of the contributor in other locales if needed
+   */
+  i18n?: Record<string, string>
   /**
    * The overriding GitHub, GitLab, Gitea username of the contributor
    */

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
@@ -364,6 +364,7 @@ export async function parseCommitAuthors(commit: MergedRawCommit, mapContributor
       const targetCreatorByName = findMapAuthorByName(mapContributors, author.name)
       if (targetCreatorByName) {
         author.name = targetCreatorByName.name ?? author.name
+        author.i18n = findMapAuthorI18n(targetCreatorByName)
         author.url = findMapAuthorLink(targetCreatorByName)
         author.avatarUrl = await newAvatarForAuthor(targetCreatorByName, author_email)
         return author
@@ -371,6 +372,7 @@ export async function parseCommitAuthors(commit: MergedRawCommit, mapContributor
       const targetCreatorByEmail = author.email && findMapAuthorByEmail(mapContributors, author.email)
       if (targetCreatorByEmail) {
         author.name = targetCreatorByEmail.name ?? author.name
+        author.i18n = findMapAuthorI18n(targetCreatorByEmail)
         author.url = findMapAuthorLink(targetCreatorByEmail)
         author.avatarUrl = await newAvatarForAuthor(targetCreatorByEmail, author_email)
         return author
@@ -444,6 +446,13 @@ export function findMapAuthorLink(creator: Contributor): string | undefined {
   }
 
   return creator.links?.[0]?.link
+}
+
+export function findMapAuthorI18n(mappedAuthor: Contributor): Record<string, string> | undefined {
+  if (mappedAuthor && mappedAuthor.i18n) {
+    return mappedAuthor.i18n
+  }
+  return undefined
 }
 
 export async function newAvatarForAuthor(mappedAuthor: Contributor | undefined, email: string): Promise<string> {


### PR DESCRIPTION
Our team took on a new project in which there was a need to localize contributor names for better internationalization.

I would like to propose my own implementation of this functionality.

In `Author` (`Contributor`) type inside `mapAuthors` option we create `i18n` field with the following structure:
```ts
i18n: {
   'locale-code': 'name',
}
```

Example:
```ts
mapAuthors: [
   {
       name: "Anton Politov",
       i18n: {
           'ru-RU': 'Антон Политов',
       },
      ...
   }
]
```

Maybe it can be helpful for someone