### PR TITLE
feat(git changelog): resolve profile picture for GitHub emails, new option to hide no data texts

### DIFF
--- a/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/en/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -146,6 +146,10 @@ export interface Options {
    */
   hideChangelogHeader?: boolean
   /**
+   * Whether to hide the changelog "No changes" text when there are no changes
+   */
+  hideChangelogNoChangesText?: boolean
+  /**
    * Whether to hide the contributors h2 header
    */
   hideContributorsHeader?: boolean

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-git-changelog/configure-ui.md
@@ -146,6 +146,10 @@ export interface Options {
    */
   hideChangelogHeader?: boolean
   /**
+   * Whether to hide the changelog "No changes" text when there are no changes
+   */
+  hideChangelogNoChangesText?: boolean
+  /**
    * Whether to hide the contributors h2 header
    */
   hideContributorsHeader?: boolean

--- a/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
+++ b/packages/vitepress-plugin-git-changelog/src/client/components/Changelog.vue
@@ -67,7 +67,7 @@ onMounted(() => {
     {{ t('changelog.title') }}
     <a class="header-anchor" :href="`#${t('changelog.titleId') || t('changelog.title')}`" :aria-label="`Permalink to '${t('changelog.title')}'`" />
   </h2>
-  <div v-if="!commits.length" :class="options.hideChangelogHeader && 'mt-6'" class="italic" opacity="70">
+  <div v-if="!commits.length && !options.hideChangelogNoChangesText" :class="options.hideChangelogHeader && 'mt-6'" class="italic" opacity="70">
     {{ t('noLogs', { omitEmpty: true }) || t('changelog.noData') }}
   </div>
   <div

--- a/packages/vitepress-plugin-git-changelog/src/client/types.ts
+++ b/packages/vitepress-plugin-git-changelog/src/client/types.ts
@@ -128,6 +128,10 @@ export interface Options {
    */
   hideChangelogHeader?: boolean
   /**
+   * Whether to hide the changelog "No changes" text when there are no changes
+   */
+  hideChangelogNoChangesText?: boolean
+  /**
    * Whether to hide the contributors h2 header
    */
   hideContributorsHeader?: boolean

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.test.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   findMapAuthorByEmail,
   findMapAuthorByName,
   findMapAuthorLink,
+  getAvatarFromGithubNoreplyAddress,
   getCoAuthors,
   mergeRawCommits,
   newAvatarForAuthor,
@@ -534,6 +535,38 @@ describe('newAvatarForAuthor', () => {
     const avatar = await newAvatarForAuthor(undefined, 'user@example.com')
 
     expect(avatar).toEqual('https://gravatar.com/avatar/b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514?d=retro')
+  })
+
+  it('should return the commit author avatar for GitHub noreply email without user ID', async () => {
+    const avatar = await newAvatarForAuthor(undefined, 'user@users.noreply.github.com')
+
+    expect(avatar).toEqual('https://avatars.githubusercontent.com/user?size=80')
+  })
+
+  it('should return the commit author avatar for GitHub noreply email with user ID', async () => {
+    const avatar = await newAvatarForAuthor(undefined, '123456+user@users.noreply.github.com')
+
+    expect(avatar).toEqual('https://avatars.githubusercontent.com/u/123456?size=80')
+  })
+})
+
+describe('getAvatarFromGithubNoreplyAddress', () => {
+  it('should return undefined for email it cannot handle', async () => {
+    const avatar = await getAvatarFromGithubNoreplyAddress('user@example.com')
+
+    expect(avatar).toEqual(undefined)
+  })
+
+  it('should return the commit author avatar for GitHub noreply email without user ID', async () => {
+    const avatar = await getAvatarFromGithubNoreplyAddress('user@users.noreply.github.com')
+
+    expect(avatar).toEqual('https://avatars.githubusercontent.com/user?size=80')
+  })
+
+  it('should return the commit author avatar for GitHub noreply email with user ID', async () => {
+    const avatar = await getAvatarFromGithubNoreplyAddress('123456+user@users.noreply.github.com')
+
+    expect(avatar).toEqual('https://avatars.githubusercontent.com/u/123456?size=80')
   })
 })
 

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
@@ -455,6 +455,7 @@ export function findMapAuthorI18n(mappedAuthor: Contributor): Record<string, str
   return undefined
 }
 
+// based on https://github.com/nolebase/integrations/issues/277#issuecomment-2254111802
 export function getAvatarFromGithubNoreplyAddress(email: string | undefined, size: number = 80): string | undefined {
   if (!email)
     return undefined

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
@@ -455,6 +455,18 @@ export function findMapAuthorI18n(mappedAuthor: Contributor): Record<string, str
   return undefined
 }
 
+function getAvatarFromGithubNoreplyAddress(email: string | undefined, size: number = 80): string | undefined {
+  if (!email)
+    return undefined
+
+  const match = email.match(/^(?:(?<userId>\d+)\+)?(?<userName>[a-zA-Z\d-]{1,39})@users.noreply.github.com$/)
+  if (!match || !match.groups)
+    return undefined
+
+  const { userName, userId } = match.groups
+  return `https://avatars.githubusercontent.com/${userId ? `u/${userId}` : userName}?size=${size}`
+}
+
 export async function newAvatarForAuthor(mappedAuthor: Contributor | undefined, email: string): Promise<string> {
   if (mappedAuthor) {
     if (mappedAuthor.avatar)
@@ -462,5 +474,10 @@ export async function newAvatarForAuthor(mappedAuthor: Contributor | undefined, 
     if (mappedAuthor.username)
       return `https://github.com/${mappedAuthor.username}.png`
   }
+
+  const githubProfilePicture = getAvatarFromGithubNoreplyAddress(email)
+  if (githubProfilePicture != null)
+    return githubProfilePicture
+
   return `https://gravatar.com/avatar/${await digestStringAsSHA256(email)}?d=retro`
 }

--- a/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
+++ b/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts
@@ -455,7 +455,7 @@ export function findMapAuthorI18n(mappedAuthor: Contributor): Record<string, str
   return undefined
 }
 
-function getAvatarFromGithubNoreplyAddress(email: string | undefined, size: number = 80): string | undefined {
+export function getAvatarFromGithubNoreplyAddress(email: string | undefined, size: number = 80): string | undefined {
   if (!email)
     return undefined
 


### PR DESCRIPTION
Resolve profile pictures for GitHub emails in commit authors.

Resolves #277

Based on @nekomeowww's suggestions: https://github.com/nolebase/integrations/issues/277#issuecomment-2254111802