### PR TITLE
docs: fix build issue in vite config

### DIFF
--- a/docs/pages/en/integrations/vitepress-plugin-enhanced-readabilities/index.md
+++ b/docs/pages/en/integrations/vitepress-plugin-enhanced-readabilities/index.md
@@ -119,13 +119,15 @@ export default defineConfig(() => {
     optimizeDeps: {
       exclude: [ // [!code ++]
         '@nolebase/vitepress-plugin-enhanced-readabilities/client', // [!code ++]
-        'vitepress' // [!code ++]
+        'vitepress', // [!code ++]
+        '@nolebase/ui', // [!code ++]
       ], // [!code ++]
     },
     ssr: { // [!code ++]
       noExternal: [ // [!code ++]
         // If there are other packages that need to be processed by Vite, you can add them here. // [!code hl]
         '@nolebase/vitepress-plugin-enhanced-readabilities', // [!code ++]
+        '@nolebase/ui', // [!code ++]
       ], // [!code ++]
     }, // [!code ++]
     plugins: [

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-enhanced-readabilities/index.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-enhanced-readabilities/index.md
@@ -87,12 +87,15 @@ export default defineConfig({
     optimizeDeps: {
       exclude: [ // [!code ++]
         '@nolebase/vitepress-plugin-enhanced-readabilities/client', // [!code ++]
+        'vitepress', // [!code ++]
+        '@nolebase/ui', // [!code ++]
       ], // [!code ++]
     },
     ssr: { // [!code ++]
       noExternal: [ // [!code ++]
         // 如果还有别的依赖需要添加的话，并排填写和配置到这里即可 // [!code hl]
         '@nolebase/vitepress-plugin-enhanced-readabilities', // [!code ++]
+        '@nolebase/ui', // [!code ++]
       ], // [!code ++]
     }, // [!code ++]
   }, // [!code ++]


### PR DESCRIPTION
Updated Vite configuration to properly handle .vue files from @nolebase/ui. Fixed "Unknown file extension '.vue'" error during Vitepress build process.

Add the following line to the `optimizeDeps.exclude` / `ssr.noExternal` section in the Vite config:

`'@nolebase/ui'`.

The build error example:

```
build error:
Unknown file extension ".vue" for /vercel/path0/node_modules/@nolebase/ui/dist/components/NuTag/index.vue
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".vue" for /vercel/path0/node_modules/@nolebase/ui/dist/components/NuTag/index.vue
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:160:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:203:36)
    at defaultLoad (node:internal/modules/esm/load:143:22)
    at async ModuleLoader.load (node:internal/modules/esm/loader:553:7)
    at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:434:45)
error: script "build" exited with code 1
Error: Command "npm run build" exited with 1
```