### PR TITLE
Fix titleid format in ru locale in vitepress-plugin-git-changelog

### DIFF
--- a/packages/vitepress-plugin-git-changelog/src/locales/ru-RU.yaml
+++ b/packages/vitepress-plugin-git-changelog/src/locales/ru-RU.yaml
@@ -1,6 +1,6 @@
 changelog:
   title: 'История изменений'
-  titleId: 'история изменений'
+  titleId: 'история-изменений'
   noData: 'Нет изменений'
   lastEdited: 'Последнее редактирование {{daysAgo}}'
   lastEditedDateFnsLocaleName: 'ru'


### PR DESCRIPTION
Fix `titleid` format in ru locale in vitepress-plugin-git-changelog