### PR TITLE
docs(breadcrumbs): fix twoslash error when build docs

### DIFF
--- a/docs/.vitepress/twoslashConfig.ts
+++ b/docs/.vitepress/twoslashConfig.ts
@@ -56,6 +56,9 @@ export const compilerOptions = {
       '@nolebase/vitepress-plugin-thumbnail-hash/*': [
         '../packages/vitepress-plugin-thumbnail-hash/src/*',
       ],
+      '@nolebase/vitepress-plugin-breadcrumbs/*': [
+        '../packages/vitepress-plugin-breadcrumbs/src/*',
+      ],
     },
     resolveJsonModule: true,
     types: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "@nolebase/ui-asciinema": "workspace:^",
     "@nolebase/ui-rive-canvas": "workspace:^",
     "@nolebase/unconfig-vitepress": "workspace:^",
+    "@nolebase/vitepress-plugin-breadcrumbs": "workspace:^",
     "@nolebase/vitepress-plugin-enhanced-mark": "workspace:^",
     "@nolebase/vitepress-plugin-enhanced-readabilities": "workspace:^",
     "@nolebase/vitepress-plugin-git-changelog": "workspace:^",

--- a/docs/pages/en/integrations/vitepress-plugin-breadcrumbs/index.md
+++ b/docs/pages/en/integrations/vitepress-plugin-breadcrumbs/index.md
@@ -49,7 +49,7 @@ In the VitePress configuration file (usually `docs/.vitepress/config.ts`, the fi
 
 ```typescript twoslash
 import { defineConfig } from 'vitepress'
-import { generateBreadcrumbsData } from '@nolebase/vitepress-plugin-breadcrumbs' // [!code ++]
+import { generateBreadcrumbsData } from '@nolebase/vitepress-plugin-breadcrumbs/vitepress' // [!code ++]
 
 export default defineConfig({
   // Other configurations...
@@ -67,6 +67,8 @@ Then please add the Breadcrumbs plugin package name `@nolebase/vitepress-plugin-
 <!--@include: @/pages/en/snippets/configure-tsconfig.md-->
 
 ```typescript twoslash
+import { defineConfig } from 'vitepress'
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   vite: { // [!code ++]

--- a/docs/pages/zh-CN/integrations/vitepress-plugin-breadcrumbs/index.md
+++ b/docs/pages/zh-CN/integrations/vitepress-plugin-breadcrumbs/index.md
@@ -49,7 +49,7 @@ bun install @nolebase/vitepress-plugin-breadcrumbs
 
 ```typescript twoslash
 import { defineConfig } from 'vitepress'
-import { generateBreadcrumbsData } from '@nolebase/vitepress-plugin-breadcrumbs' // [!code ++]
+import { generateBreadcrumbsData } from '@nolebase/vitepress-plugin-breadcrumbs/vitepress' // [!code ++]
 
 export default defineConfig({
   // 其它各种配置...
@@ -67,6 +67,8 @@ export default defineConfig({
 <!--@include: @/pages/zh-CN/snippets/configure-tsconfig.md-->
 
 ```typescript twoslash
+import { defineConfig } from 'vitepress'
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   vite: { // [!code ++]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@nolebase/unconfig-vitepress':
         specifier: workspace:^
         version: link:../packages/unconfig-vitepress
+      '@nolebase/vitepress-plugin-breadcrumbs':
+        specifier: workspace:^
+        version: link:../packages/vitepress-plugin-breadcrumbs
       '@nolebase/vitepress-plugin-enhanced-mark':
         specifier: workspace:^
         version: link:../packages/vitepress-plugin-enhanced-mark


### PR DESCRIPTION
close #351 