### PR TITLE
style: breadcrumbs now warps line correctly

### DIFF
--- a/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
+++ b/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
@@ -12,7 +12,8 @@ const breadcrumbs = (frontmatter.value.breadcrumbs ?? []) as {
 <template>
   <div class="breadcrumbs">
     <span v-for="item in breadcrumbs" :key="item.link">
-      <a :href="item.link">{{ item.title }}</a>
+      <a v-if="item.link" :href="item.link">{{ item.title }}</a>
+      <span v-else>{{ item.title }}</span>
     </span>
   </div>
 </template>

--- a/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
+++ b/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
@@ -2,45 +2,48 @@
 import { useData } from 'vitepress'
 
 const { frontmatter } = useData()
+
+const breadcrumbs = (frontmatter.value.breadcrumbs ?? []) as {
+  title: string
+  link: string
+}[]
 </script>
 
 <template>
-  <div class="vp-nolebase-breadcrumbs">
-    <span v-for="item in frontmatter.breadcrumbs" :key="item">
-      <a v-if="item.link" :href="item.link">{{ item.title }}</a>
-      <span v-else>{{ item.title }}</span>
+  <div class="breadcrumbs">
+    <span v-for="item in breadcrumbs" :key="item">
+      <a :href="item.link">{{ item.title }}</a>
     </span>
   </div>
 </template>
 
 <style scoped>
-.vp-nolebase-breadcrumbs {
-  display: flex;
-  gap: 8px;
+.breadcrumbs {
   font-size: 14px;
   margin-bottom: 2rem;
 }
 
-.vp-nolebase-breadcrumbs span {
+.breadcrumbs span {
   transition: color 0.25s, opacity 0.25s;
   color: var(--vp-c-text-2);
 }
 
-.vp-nolebase-breadcrumbs span:hover {
+.breadcrumbs span:hover {
   color: var(--vp-c-brand-1);
 }
 
-.vp-nolebase-breadcrumbs span:last-child {
+.breadcrumbs span:last-child {
   color: var(--vp-c-text-1);
 }
 
-.vp-nolebase-breadcrumbs span:last-child:hover {
+.breadcrumbs span:last-child:hover {
   color: var(--vp-c-brand-1);
 }
 
-.vp-nolebase-breadcrumbs span:not(:first-child)::before {
-  content: '/';
-  padding-right: 8px;
+.breadcrumbs span:not(:first-child)::before {
+  content: "/";
+  padding-left: 4px;
+  padding-right: 4px;
   color: var(--vp-c-text-3);
 }
 </style>

--- a/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
+++ b/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
@@ -11,36 +11,36 @@ const breadcrumbs = (frontmatter.value.breadcrumbs ?? []) as {
 
 <template>
   <div class="breadcrumbs">
-    <span v-for="item in breadcrumbs" :key="item">
+    <span v-for="item in breadcrumbs" :key="item.link">
       <a :href="item.link">{{ item.title }}</a>
     </span>
   </div>
 </template>
 
 <style scoped>
-.breadcrumbs {
+.vp-nolebase-breadcrumbs {
   font-size: 14px;
   margin-bottom: 2rem;
 }
 
-.breadcrumbs span {
+.vp-nolebase-breadcrumbs span {
   transition: color 0.25s, opacity 0.25s;
   color: var(--vp-c-text-2);
 }
 
-.breadcrumbs span:hover {
+.vp-nolebase-breadcrumbs span:hover {
   color: var(--vp-c-brand-1);
 }
 
-.breadcrumbs span:last-child {
+.vp-nolebase-breadcrumbs span:last-child {
   color: var(--vp-c-text-1);
 }
 
-.breadcrumbs span:last-child:hover {
+.vp-nolebase-breadcrumbs span:last-child:hover {
   color: var(--vp-c-brand-1);
 }
 
-.breadcrumbs span:not(:first-child)::before {
+.vp-nolebase-breadcrumbs span:not(:first-child)::before {
   content: "/";
   padding-left: 4px;
   padding-right: 4px;

--- a/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
+++ b/packages/vitepress-plugin-breadcrumbs/src/client/components/NolebaseBreadcrumbs.vue
@@ -10,7 +10,7 @@ const breadcrumbs = (frontmatter.value.breadcrumbs ?? []) as {
 </script>
 
 <template>
-  <div class="breadcrumbs">
+  <div class="vp-nolebase-breadcrumbs">
     <span v-for="item in breadcrumbs" :key="item.link">
       <a v-if="item.link" :href="item.link">{{ item.title }}</a>
       <span v-else>{{ item.title }}</span>


### PR DESCRIPTION
## Problem:

Old version of breadcrumbs does not wrap line correctly, this patch fixes this by just removing the flex.

Before:

![image](https://github.com/user-attachments/assets/2828cd5e-1cdf-4908-a851-53bcace734b3)


After:

![image](https://github.com/user-attachments/assets/1039854c-9f4f-4c68-9782-8871ef6bc36e)
