### PR TITLE
docs(markdown-it-unlazy-img): correct installation command

### DIFF
--- a/docs/pages/zh-CN/integrations/markdown-it-unlazy-img/index.md
+++ b/docs/pages/zh-CN/integrations/markdown-it-unlazy-img/index.md
@@ -13,24 +13,24 @@ import packageJSON from '~/packages/markdown-it-unlazy-img/package.json'
 
 ## 安装
 
-通过运行以下命令将 `@nolebase/markdown-it-bi-unlazy-img` 安装到您的项目依赖项中：
+通过运行以下命令将 `@nolebase/markdown-it-unlazy-img` 安装到您的项目依赖项中：
 
 ::: code-group
 
 ```shell [@antfu/ni]
-ni @nolebase/markdown-it-bi-unlazy-img -D
+ni @nolebase/markdown-it-unlazy-img -D
 ```
 
 ```shell [pnpm]
-pnpm add @nolebase/markdown-it-bi-unlazy-img -D
+pnpm add @nolebase/markdown-it-unlazy-img -D
 ```
 
 ```shell [npm]
-npm install @nolebase/markdown-it-bi-unlazy-img -D
+npm install @nolebase/markdown-it-unlazy-img -D
 ```
 
 ```shell [yarn]
-yarn add @nolebase/markdown-it-bi-unlazy-img -D
+yarn add @nolebase/markdown-it-unlazy-img -D
 ```
 
 :::


### PR DESCRIPTION
# Update zh-CN documentation for `markdown-it-unlazy-img`

## Issue https://github.com/nolebase/integrations/issues/305
In the zh-CN version of the `markdown-it-unlazy-img` documentation, the package name in the installation command has not been updated. Using the incorrect package name (`markdown-it-bi-unlazy-img`) will result in a package not found error. 

![image](https://github.com/user-attachments/assets/11c52270-fe94-4edd-a538-16368199350d)

![0901386c0d105c21ee35f7d683d26598](https://github.com/user-attachments/assets/0f391fd8-4cb4-45e7-8f43-a73a13424ded)

The English documentation has the correct package name.

![image](https://github.com/user-attachments/assets/3b701007-aec3-4b00-971a-512a511a123d)

## Solution
Update the package name in the installation command from `markdown-it-bi-unlazy-img` to `markdown-it-unlazy-img` in the zh-CN documentation.

## Changes
- Corrected the package name in the installation command in the `zh-CN` documentation `markdown-it-unlazy-img` file.
