### PR TITLE
fix(recentUpdates): path parsing error

### DIFF
--- a/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
+++ b/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
@@ -230,7 +230,7 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
         for (const rewrite of opts.rewrites) {
           url = url.replace(rewrite.from, rewrite.to)
         }
-        url = '/' + url
+        url = `/${url}`
 
         const entry = {
           title,

--- a/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
+++ b/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
@@ -214,9 +214,9 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
             title = matches[0]
           }
         }
-        
+
         let url = ''
-        const fileRelativePath = '/' + relative(cwd(), file)
+        const fileRelativePath = relative(cwd(), file)
 
         if (fileRelativePath.endsWith('.md')) {
           if (fileRelativePath.endsWith('index.md')) {
@@ -230,6 +230,7 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
         for (const rewrite of opts.rewrites) {
           url = url.replace(rewrite.from, rewrite.to)
         }
+        url = '/' + url
 
         const entry = {
           title,

--- a/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
+++ b/packages/vitepress-plugin-index/src/vitepress/recentUpdates.ts
@@ -168,7 +168,7 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
 
   return {
     async load() {
-      const files = await glob(join(opts.dir, '**/*.md'), {
+      const files = await glob(join(opts.dir, '**/*.md').replaceAll('\\', '/'), {
         absolute: true,
         cwd: cwd(),
         ignore: opts.ignores,
@@ -214,14 +214,16 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
             title = matches[0]
           }
         }
+        
+        let url = ''
+        const fileRelativePath = '/' + relative(cwd(), file)
 
-        let url = relative(cwd(), file)
-        if (url.endsWith('.md')) {
-          if (url.endsWith('index.md')) {
-            url = url.replace(/index\.md$/, 'index.html')
+        if (fileRelativePath.endsWith('.md')) {
+          if (fileRelativePath.endsWith('index.md')) {
+            url = fileRelativePath.replace(/index\.md$/, 'index.html')
           }
           else {
-            url = url.replace(/\.md$/, '.html')
+            url = fileRelativePath.replace(/\.md$/, '.html')
           }
         }
 
@@ -232,7 +234,7 @@ export function createRecentUpdatesLoader(options?: RecentUpdatesContentLoaderOp
         const entry = {
           title,
           lastUpdated: lastUpdatedTimestamp,
-          filePath: relative(cwd(), file),
+          filePath: fileRelativePath,
           category: '',
           url,
         }


### PR DESCRIPTION
https://github.com/nolebase/nolebase/issues/143
![image](https://github.com/user-attachments/assets/976e93dd-717c-45e0-b63a-95b106d6cc38)

The missing slash is recognized as a relative path and is now added when generating the data,
should this be added when rendering?

Additionally, in a Windows environment (Node.js v18.19.0), patterns using backslashes cannot resolve files. They need to be replaced with forward slashes.

