### PR TITLE
feat(bi-link): allow invalid link

### DIFF
--- a/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -114,5 +114,17 @@ interface BiDirectionalLinksOptions {
    * @default false
    */
   noNoMatchedFileWarning?: boolean
+  /**
+   * Generate an error link or a link to a specific page when no matched file is found.
+   *
+   * @default false
+   */
+  noNoMatchedStillWork?: boolean
+  /**
+   * Force a relative path instead of an absolute path
+   *
+   * @default false
+   */
+  isRelativePath?: boolean
 }
 ```

--- a/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -119,7 +119,7 @@ interface BiDirectionalLinksOptions {
    *
    * @default false
    */
-  noNoMatchedStillWork?: boolean
+  stillRenderNoMatched?: boolean
   /**
    * Force a relative path instead of an absolute path
    *

--- a/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/en/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -117,6 +117,11 @@ interface BiDirectionalLinksOptions {
   /**
    * Generate an error link or a link to a specific page when no matched file is found.
    *
+   * When you use this option, you should define a css style for
+   * `.nolebase-route-link-invalid` (or `a[href="#"] {}`) to
+   * distinguish the invalid link from the normal link. Such as:
+   * `a.nolebase-route-link-invalid { color: red; opacity: 0.6; }`
+   *
    * @default false
    */
   stillRenderNoMatched?: boolean

--- a/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -115,7 +115,7 @@ interface BiDirectionalLinksOptions {
    *
    * @default false
    */
-  noNoMatchedStillWork?: boolean
+  stillRenderNoMatched?: boolean
   /**
    * Force a relative path instead of an absolute path
    *

--- a/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -110,5 +110,17 @@ interface BiDirectionalLinksOptions {
    * @default false
    */
   noNoMatchedFileWarning?: boolean
+  /**
+   * Generate an error link or a link to a specific page when no matched file is found.
+   *
+   * @default false
+   */
+  noNoMatchedStillWork?: boolean
+  /**
+   * Force a relative path instead of an absolute path
+   *
+   * @default false
+   */
+  isRelativePath?: boolean
 }
 ```

--- a/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
+++ b/docs/pages/zh-CN/integrations/markdown-it-bi-directional-links/getting-started.md
@@ -113,6 +113,11 @@ interface BiDirectionalLinksOptions {
   /**
    * Generate an error link or a link to a specific page when no matched file is found.
    *
+   * When you use this option, you should define a css style for
+   * `.nolebase-route-link-invalid` to distinguish the invalid link
+   * from the normal link. Such as:
+   * `a.nolebase-route-link-invalid { color: red; opacity: 0.6; }`
+   *
    * @default false
    */
   stillRenderNoMatched?: boolean

--- a/packages/markdown-it-bi-directional-links/src/index.ts
+++ b/packages/markdown-it-bi-directional-links/src/index.ts
@@ -205,6 +205,12 @@ export interface BiDirectionalLinksOptions {
    */
   noNoMatchedFileWarning?: boolean
   /**
+   * Generate an error link or a link to a specific page when no matched file is found.
+   *
+   * @default false
+   */
+  noNoMatchedStillWork?: boolean
+  /**
    * Force a relative path instead of an absolute path
    *
    * @default false
@@ -226,6 +232,7 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => Plugin
   const includes = options?.includesPatterns ?? []
   const debugOn = options?.debug ?? false
   const noNoMatchedFileWarning = options?.noNoMatchedFileWarning ?? false
+  const noNoMatchedStillWork = options?.noNoMatchedStillWork ?? false
   const isRelativePath = options?.isRelativePath ?? false
 
   const possibleBiDirectionalLinksInCleanBaseNameOfFilePaths: Record<string, string> = {}
@@ -339,7 +346,10 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => Plugin
       if (matchedHrefSingleOrArray === null || (Array.isArray(matchedHrefSingleOrArray) && matchedHrefSingleOrArray.length === 0)) {
         const relevantPath = findTheMostRelevantOne(possibleBiDirectionalLinksInCleanBaseNameOfFilePaths, possibleBiDirectionalLinksInFullFilePaths, osSpecificHref)
         logNoMatchedFileWarning(rootDir, inputContent, markupTextContent, href, osSpecificHref, state.env.path, !noNoMatchedFileWarning, relevantPath)
-
+        if (noNoMatchedStillWork) {
+          genLink(state, '', href, md, href, link, true)
+          return true
+        }
         return false
       }
 

--- a/packages/markdown-it-bi-directional-links/src/index.ts
+++ b/packages/markdown-it-bi-directional-links/src/index.ts
@@ -209,7 +209,7 @@ export interface BiDirectionalLinksOptions {
    *
    * @default false
    */
-  noNoMatchedStillWork?: boolean
+  stillRenderNoMatched?: boolean
   /**
    * Force a relative path instead of an absolute path
    *
@@ -232,7 +232,7 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => Plugin
   const includes = options?.includesPatterns ?? []
   const debugOn = options?.debug ?? false
   const noNoMatchedFileWarning = options?.noNoMatchedFileWarning ?? false
-  const noNoMatchedStillWork = options?.noNoMatchedStillWork ?? false
+  const stillRenderNoMatched = options?.stillRenderNoMatched ?? false
   const isRelativePath = options?.isRelativePath ?? false
 
   const possibleBiDirectionalLinksInCleanBaseNameOfFilePaths: Record<string, string> = {}
@@ -346,7 +346,7 @@ export const BiDirectionalLinks: (options?: BiDirectionalLinksOptions) => Plugin
       if (matchedHrefSingleOrArray === null || (Array.isArray(matchedHrefSingleOrArray) && matchedHrefSingleOrArray.length === 0)) {
         const relevantPath = findTheMostRelevantOne(possibleBiDirectionalLinksInCleanBaseNameOfFilePaths, possibleBiDirectionalLinksInFullFilePaths, osSpecificHref)
         logNoMatchedFileWarning(rootDir, inputContent, markupTextContent, href, osSpecificHref, state.env.path, !noNoMatchedFileWarning, relevantPath)
-        if (noNoMatchedStillWork) {
+        if (stillRenderNoMatched) {
           genLink(state, '', href, md, href, link, true)
           return true
         }

--- a/packages/markdown-it-bi-directional-links/src/index.ts
+++ b/packages/markdown-it-bi-directional-links/src/index.ts
@@ -207,6 +207,11 @@ export interface BiDirectionalLinksOptions {
   /**
    * Generate an error link or a link to a specific page when no matched file is found.
    *
+   * When you use this option, you should define a css style for
+   * `.nolebase-route-link-invalid` (or `a[href="#"] {}`) to
+   * distinguish the invalid link from the normal link. Such as:
+   * `a.nolebase-route-link-invalid { color: red; opacity: 0.6; }`
+   *
    * @default false
    */
   stillRenderNoMatched?: boolean

--- a/packages/markdown-it-bi-directional-links/src/utils.ts
+++ b/packages/markdown-it-bi-directional-links/src/utils.ts
@@ -32,7 +32,24 @@ export function genLink(
   md: MarkdownIt,
   href: string,
   link: RegExpMatchArray,
+  isInvalid = false,
 ) {
+  // Work when option noNoMatchedStillWork, like Wikipedia's invalid link
+  if (isInvalid) {
+    const openToken = state.push('link_open', 'a', 1)
+    openToken.attrSet('class', 'route-link')
+    openToken.attrSet('href', '#') // invalid link without resolvedNewHref, href or `javascript:void(0);`
+    openToken.attrSet('target', '_target')
+    openToken.attrSet('style', 'color: red; opacity: 0.6;') // style cover method: use class or use `a[href="#"] {}`
+
+    const pushedToken = state.push('text', '', 0)
+    pushedToken.content = text
+
+    state.push('link_close', 'a', -1)
+    state.pos += link[0].length
+    return
+  }
+
   // Create new link_open
   const openToken = state.push('link_open', 'a', 1)
   openToken.attrSet('href', resolvedNewHref)

--- a/packages/markdown-it-bi-directional-links/src/utils.ts
+++ b/packages/markdown-it-bi-directional-links/src/utils.ts
@@ -40,7 +40,6 @@ export function genLink(
     openToken.attrSet('class', 'route-link nolebase-route-link-invalid')
     openToken.attrSet('href', '#') // invalid link without resolvedNewHref, href or `javascript:void(0);`
     openToken.attrSet('target', '_target')
-    // Recommended style: openToken.attrSet('style', 'color: red; opacity: 0.6;') // style cover method: use class `.nolebase-route-link-invalid` or use `a[href="#"] {}`
 
     const pushedToken = state.push('text', '', 0)
     pushedToken.content = text

--- a/packages/markdown-it-bi-directional-links/src/utils.ts
+++ b/packages/markdown-it-bi-directional-links/src/utils.ts
@@ -34,13 +34,13 @@ export function genLink(
   link: RegExpMatchArray,
   isInvalid = false,
 ) {
-  // Work when option noNoMatchedStillWork, like Wikipedia's invalid link
+  // Work when option `stillRenderNoMatched`, like Wikipedia's invalid link
   if (isInvalid) {
     const openToken = state.push('link_open', 'a', 1)
-    openToken.attrSet('class', 'route-link')
+    openToken.attrSet('class', 'route-link nolebase-route-link-invalid')
     openToken.attrSet('href', '#') // invalid link without resolvedNewHref, href or `javascript:void(0);`
     openToken.attrSet('target', '_target')
-    openToken.attrSet('style', 'color: red; opacity: 0.6;') // style cover method: use class or use `a[href="#"] {}`
+    // Recommended style: openToken.attrSet('style', 'color: red; opacity: 0.6;') // style cover method: use class `.nolebase-route-link-invalid` or use `a[href="#"] {}`
 
     const pushedToken = state.push('text', '', 0)
     pushedToken.content = text


### PR DESCRIPTION
## 新功能

**增加选项**：noNoMatchedStillWork

**预期效果**：失效链接为偏红色的a标签

## 实例

**网站实例1**：维基百科（wikipedia），点击失效链接会进入到创建该词条的新页面（功能不支持，只是模拟样式）

https://zh.wikipedia.org/wiki/%E6%95%B0%E5%AD%A6%E5%AD%A6%E7%A7%91%E5%88%86%E7%B1%BB%E6%A0%87%E5%87%86

![图片](https://github.com/user-attachments/assets/0b420238-e314-47e5-821b-43994ce05ead)

**网站实例2**：（绿色的链接没有对应内容）

https://www.bananaspace.org/wiki/%E9%A6%99%E8%95%89%E7%A9%BA%E9%97%B4:%E5%86%99%E4%BD%9C%E8%AE%A1%E5%88%92

![图片](https://github.com/user-attachments/assets/41b8500a-a3d4-4ba5-96ad-850509b5a743)

**软件实例**：Obsidian

这个默认在样式上似乎不区分链接是否有效，反正哪怕是没有对应页他也渲染成a标签。只是点击时不再跳转，而是自动创建该页面

## 原效果

**原来效果**：（稍微有些丑陋）

![图片](https://github.com/user-attachments/assets/1dd17701-8472-4cfa-b454-bbc87d5b526c)