### PR TITLE
fix(ui-asciinema): controls is boolean or 'auto' [#400]

### DIFF
--- a/packages/ui-asciinema/src/asciinema.d.ts
+++ b/packages/ui-asciinema/src/asciinema.d.ts
@@ -166,7 +166,7 @@ declare module 'asciinema-player' {
      *
      * @default "auto"
      */
-    controls?: boolean
+    controls?: boolean | 'auto'
     /**
      * Defines a list of timeline markers.
      *

--- a/packages/ui-asciinema/src/components/NuAsciinemaPlayer.vue
+++ b/packages/ui-asciinema/src/components/NuAsciinemaPlayer.vue
@@ -153,7 +153,7 @@ const props = defineProps<{
    *
    * @default "auto"
    */
-  controls?: boolean
+  controls?: boolean | 'auto'
   /**
    * Defines a list of timeline markers.
    *


### PR DESCRIPTION
- Fixes #400

ui-asciinema's `controls` can be `true`, `false`, or `'auto'`.

Before, the type did not allow `'auto'`.

With this PR, the type allows all possible values.

I modified both of these files manually. Not sure if the `d.ts` update was supposed to be done by some automated process — I ran the build `pnpm run packages:build` after changing only the Vue component file, and the `d.ts` didn't change.