### PR TITLE
ui-asciinema docs: ssr.noExternal motivation, Markdown use, global registration

### DIFF
--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -99,13 +99,13 @@ export default defineConfig({
 })
 ```
 
-If a component is only used by a few pages, it's recommended to explicitly import them where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
+If the component is only used by a few pages, it's recommended to explicitly import it and the asciinema-player stylesheet where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
 
 - Markdown
 
     ```html
     <script setup>
-    // somewhere.vue
+    // somewhere.md
     import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
     import 'asciinema-player/dist/bundle/asciinema-player.css'
     </script>
@@ -145,10 +145,10 @@ If a component is only used by a few pages, it's recommended to explicitly impor
     </template>
     ```
 
-If a component is going to be used on most of the pages, they can be registered globally by customizing the Vue app instance.
+If the component is going to be used on most of the pages, it and the asciinema-player stylesheet can be registered globally by customizing the VitePress Vue app instance.
 
 ```ts
-// [**]/.vitepress/theme/index.ts
+// **/.vitepress/theme/index.ts
 import { NuAsciinemaPlayer } from "@nolebase/ui-asciinema";
 import "asciinema-player/dist/bundle/asciinema-player.css";
 
@@ -162,6 +162,8 @@ export default {
 - Markdown
 
     ```html
+    <!-- somewhere.md -->
+
     <NuAsciinemaPlayer
       src="/asciinema/test-nyancat.cast"
       :preload="true"
@@ -177,6 +179,8 @@ export default {
 - Vue
 
     ```vue
+    <!-- somewhere.vue -->
+
     <template>
       <NuAsciinemaPlayer
         src="/asciinema/test-nyancat.cast"

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -46,17 +46,23 @@ yarn add @nolebase/ui-asciinema
 
 ## Usage
 
-```js
+```ts
 // vite.config.ts
 export default defineConfig({
-  ssr: {
-    noExternal: [
-      // If there are other packages that need to be processed by Vite, you can add them here.
-      '@nolebase/ui-asciinema',
-    ],
+  vite: {
+    ssr: {
+      noExternal: [
+        "@nolebase/ui-asciinema",
+      ],
+    },
   },
 })
 ```
+
+Refs:
+
+- [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
+- [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
 
 ```vue
 <script setup>

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -158,10 +158,13 @@ export default {
     </template>
     ```
 
-
 Refs:
 
 - [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components)
+
+## Options
+
+Refer to [asciinema.d.ts](https://github.com/nolebase/integrations/blob/main/packages/ui-asciinema/src/asciinema.d.ts).
 
 ## Acknowledgements
 

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -46,10 +46,48 @@ yarn add @nolebase/ui-asciinema
 
 ## Usage
 
-Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build.
+Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build. (Ref: [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals).)
 
 ```ts
 // vite.config.ts
+export default defineConfig({
+  ssr: {
+    noExternal: [
+      "@nolebase/ui-asciinema",
+    ],
+  },
+})
+```
+
+Then import `NuAsciinemaPlayer` and asciinema-player's stylesheet in your Vue file. (Ref: [asciinema-player's styling docs](https://docs.asciinema.org/manual/player/quick-start/#npm-package).)
+
+```vue
+<script setup>
+// somewhere.vue
+import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+import 'asciinema-player/dist/bundle/asciinema-player.css'
+</script>
+
+<template>
+  <NuAsciinemaPlayer
+    src="/asciinema/test-nyancat.cast"
+    :preload="true"
+    :cols="400"
+    :rows="40"
+    :auto-play="true"
+    :controls="true"
+    :terminal-font-size="'12px'"
+    :loop="true"
+  />
+</template>
+```
+
+### VitePress
+
+Instead of configuring Vite's `ssr.noExternal` in a `vite.config.ts`, you can configure it in the VitePress `vite` config. (Ref: [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite).)
+
+```ts
+// **/.vitepress/config.ts
 export default defineConfig({
   vite: {
     ssr: {
@@ -60,11 +98,6 @@ export default defineConfig({
   },
 })
 ```
-
-Refs:
-
-- [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
-- [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
 
 If a component is only used by a few pages, it's recommended to explicitly import them where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
 
@@ -158,9 +191,7 @@ export default {
     </template>
     ```
 
-Refs:
-
-- [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components)
+Ref: [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components).
 
 ## Options
 

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -46,6 +46,8 @@ yarn add @nolebase/ui-asciinema
 
 ## Usage
 
+Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build.
+
 ```ts
 // vite.config.ts
 export default defineConfig({

--- a/docs/pages/en/ui/asciinema-player/index.md
+++ b/docs/pages/en/ui/asciinema-player/index.md
@@ -66,26 +66,102 @@ Refs:
 - [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
 - [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
 
-```vue
-<script setup>
-// somewhere.vue
-import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
-import 'asciinema-player/dist/bundle/asciinema-player.css'
-</script>
+If a component is only used by a few pages, it's recommended to explicitly import them where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
 
-<template>
-  <NuAsciinemaPlayer
-    src="/asciinema/test-nyancat.cast"
-    :preload="true"
-    :cols="400"
-    :rows="40"
-    :auto-play="true"
-    :controls="true"
-    :terminal-font-size="'12px'"
-    :loop="true"
-  />
-</template>
+- Markdown
+
+    ```html
+    <script setup>
+    // somewhere.vue
+    import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+    import 'asciinema-player/dist/bundle/asciinema-player.css'
+    </script>
+
+    <NuAsciinemaPlayer
+      src="/asciinema/test-nyancat.cast"
+      :preload="true"
+      :cols="400"
+      :rows="40"
+      :auto-play="true"
+      :controls="true"
+      :terminal-font-size="'12px'"
+      :loop="true"
+    />
+    ```
+
+- Vue
+
+    ```vue
+    <script setup>
+    // somewhere.vue
+    import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+    import 'asciinema-player/dist/bundle/asciinema-player.css'
+    </script>
+
+    <template>
+      <NuAsciinemaPlayer
+        src="/asciinema/test-nyancat.cast"
+        :preload="true"
+        :cols="400"
+        :rows="40"
+        :auto-play="true"
+        :controls="true"
+        :terminal-font-size="'12px'"
+        :loop="true"
+      />
+    </template>
+    ```
+
+If a component is going to be used on most of the pages, they can be registered globally by customizing the Vue app instance.
+
+```ts
+// [**]/.vitepress/theme/index.ts
+import { NuAsciinemaPlayer } from "@nolebase/ui-asciinema";
+import "asciinema-player/dist/bundle/asciinema-player.css";
+
+export default {
+  enhanceApp({ app, router, siteData }) {
+    app.component("NuAsciinemaPlayer", NuAsciinemaPlayer);
+  }
+}
 ```
+
+- Markdown
+
+    ```html
+    <NuAsciinemaPlayer
+      src="/asciinema/test-nyancat.cast"
+      :preload="true"
+      :cols="400"
+      :rows="40"
+      :auto-play="true"
+      :controls="true"
+      :terminal-font-size="'12px'"
+      :loop="true"
+    />
+    ```
+
+- Vue
+
+    ```vue
+    <template>
+      <NuAsciinemaPlayer
+        src="/asciinema/test-nyancat.cast"
+        :preload="true"
+        :cols="400"
+        :rows="40"
+        :auto-play="true"
+        :controls="true"
+        :terminal-font-size="'12px'"
+        :loop="true"
+      />
+    </template>
+    ```
+
+
+Refs:
+
+- [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components)
 
 ## Acknowledgements
 

--- a/docs/pages/zh-CN/ui/asciinema-player/index.md
+++ b/docs/pages/zh-CN/ui/asciinema-player/index.md
@@ -46,10 +46,48 @@ yarn add @nolebase/ui-asciinema
 
 ## 用法
 
-Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build.
+Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build. (Ref: [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals).)
 
 ```ts
 // vite.config.ts
+export default defineConfig({
+  ssr: {
+    noExternal: [
+      "@nolebase/ui-asciinema",
+    ],
+  },
+})
+```
+
+Then import `NuAsciinemaPlayer` and asciinema-player's stylesheet in your Vue file. (Ref: [asciinema-player's styling docs](https://docs.asciinema.org/manual/player/quick-start/#npm-package).)
+
+```vue
+<script setup>
+// somewhere.vue
+import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+import 'asciinema-player/dist/bundle/asciinema-player.css'
+</script>
+
+<template>
+  <NuAsciinemaPlayer
+    src="/asciinema/test-nyancat.cast"
+    :preload="true"
+    :cols="400"
+    :rows="40"
+    :auto-play="true"
+    :controls="true"
+    :terminal-font-size="'12px'"
+    :loop="true"
+  />
+</template>
+```
+
+### VitePress
+
+Instead of configuring Vite's `ssr.noExternal` in a `vite.config.ts`, you can configure it in the VitePress `vite` config. (Ref: [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite).)
+
+```ts
+// **/.vitepress/config.ts
 export default defineConfig({
   vite: {
     ssr: {
@@ -61,18 +99,13 @@ export default defineConfig({
 })
 ```
 
-Refs:
-
-- [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
-- [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
-
-If a component is only used by a few pages, it's recommended to explicitly import them where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
+If the component is only used by a few pages, it's recommended to explicitly import it and the asciinema-player stylesheet where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
 
 - Markdown
 
     ```html
     <script setup>
-    // somewhere.vue
+    // somewhere.md
     import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
     import 'asciinema-player/dist/bundle/asciinema-player.css'
     </script>
@@ -112,10 +145,10 @@ If a component is only used by a few pages, it's recommended to explicitly impor
     </template>
     ```
 
-If a component is going to be used on most of the pages, they can be registered globally by customizing the Vue app instance.
+If the component is going to be used on most of the pages, it and the asciinema-player stylesheet can be registered globally by customizing the VitePress Vue app instance.
 
 ```ts
-// [**]/.vitepress/theme/index.ts
+// **/.vitepress/theme/index.ts
 import { NuAsciinemaPlayer } from "@nolebase/ui-asciinema";
 import "asciinema-player/dist/bundle/asciinema-player.css";
 
@@ -129,6 +162,8 @@ export default {
 - Markdown
 
     ```html
+    <!-- somewhere.md -->
+
     <NuAsciinemaPlayer
       src="/asciinema/test-nyancat.cast"
       :preload="true"
@@ -144,6 +179,8 @@ export default {
 - Vue
 
     ```vue
+    <!-- somewhere.vue -->
+
     <template>
       <NuAsciinemaPlayer
         src="/asciinema/test-nyancat.cast"
@@ -158,9 +195,7 @@ export default {
     </template>
     ```
 
-Refs:
-
-- [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components)
+Ref: [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components).
 
 ## Options
 

--- a/docs/pages/zh-CN/ui/asciinema-player/index.md
+++ b/docs/pages/zh-CN/ui/asciinema-player/index.md
@@ -46,6 +46,8 @@ yarn add @nolebase/ui-asciinema
 
 ## 用法
 
+Add the package to Vite's `ssr.noExternal` configuration. Without this, your site may not build.
+
 ```ts
 // vite.config.ts
 export default defineConfig({
@@ -64,26 +66,105 @@ Refs:
 - [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
 - [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
 
-```vue
-<script setup>
-// somewhere.vue
-import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
-import 'asciinema-player/dist/bundle/asciinema-player.css'
-</script>
+If a component is only used by a few pages, it's recommended to explicitly import them where they are used. This allows them to be properly code-split and only loaded when the relevant pages are shown:
 
-<template>
-  <NuAsciinemaPlayer
-    src="/asciinema/test-nyancat.cast"
-    :preload="true"
-    :cols="400"
-    :rows="40"
-    :auto-play="true"
-    :controls="true"
-    :terminal-font-size="'12px'"
-    :loop="true"
-  />
-</template>
+- Markdown
+
+    ```html
+    <script setup>
+    // somewhere.vue
+    import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+    import 'asciinema-player/dist/bundle/asciinema-player.css'
+    </script>
+
+    <NuAsciinemaPlayer
+      src="/asciinema/test-nyancat.cast"
+      :preload="true"
+      :cols="400"
+      :rows="40"
+      :auto-play="true"
+      :controls="true"
+      :terminal-font-size="'12px'"
+      :loop="true"
+    />
+    ```
+
+- Vue
+
+    ```vue
+    <script setup>
+    // somewhere.vue
+    import { NuAsciinemaPlayer } from '@nolebase/ui-asciinema'
+    import 'asciinema-player/dist/bundle/asciinema-player.css'
+    </script>
+
+    <template>
+      <NuAsciinemaPlayer
+        src="/asciinema/test-nyancat.cast"
+        :preload="true"
+        :cols="400"
+        :rows="40"
+        :auto-play="true"
+        :controls="true"
+        :terminal-font-size="'12px'"
+        :loop="true"
+      />
+    </template>
+    ```
+
+If a component is going to be used on most of the pages, they can be registered globally by customizing the Vue app instance.
+
+```ts
+// [**]/.vitepress/theme/index.ts
+import { NuAsciinemaPlayer } from "@nolebase/ui-asciinema";
+import "asciinema-player/dist/bundle/asciinema-player.css";
+
+export default {
+  enhanceApp({ app, router, siteData }) {
+    app.component("NuAsciinemaPlayer", NuAsciinemaPlayer);
+  }
+}
 ```
+
+- Markdown
+
+    ```html
+    <NuAsciinemaPlayer
+      src="/asciinema/test-nyancat.cast"
+      :preload="true"
+      :cols="400"
+      :rows="40"
+      :auto-play="true"
+      :controls="true"
+      :terminal-font-size="'12px'"
+      :loop="true"
+    />
+    ```
+
+- Vue
+
+    ```vue
+    <template>
+      <NuAsciinemaPlayer
+        src="/asciinema/test-nyancat.cast"
+        :preload="true"
+        :cols="400"
+        :rows="40"
+        :auto-play="true"
+        :controls="true"
+        :terminal-font-size="'12px'"
+        :loop="true"
+      />
+    </template>
+    ```
+
+Refs:
+
+- [VitePress Registering Global Components docs](https://vitepress.dev/guide/extending-default-theme#registering-global-components)
+
+## Options
+
+Refer to [asciinema.d.ts](https://github.com/nolebase/integrations/blob/main/packages/ui-asciinema/src/asciinema.d.ts).
 
 ## 致谢
 

--- a/docs/pages/zh-CN/ui/asciinema-player/index.md
+++ b/docs/pages/zh-CN/ui/asciinema-player/index.md
@@ -46,17 +46,23 @@ yarn add @nolebase/ui-asciinema
 
 ## 用法
 
-```js
+```ts
 // vite.config.ts
 export default defineConfig({
-  ssr: {
-    noExternal: [
-      // If there are other packages that need to be processed by Vite, you can add them here.
-      '@nolebase/ui-asciinema',
-    ],
+  vite: {
+    ssr: {
+      noExternal: [
+        "@nolebase/ui-asciinema",
+      ],
+    },
   },
 })
 ```
+
+Refs:
+
+- [VitePress's Vite configuration docs](https://vitepress.dev/reference/site-config#vite)
+- [Vite's `ssr.noExternal` config docs](https://vitejs.dev/guide/ssr.html#ssr-externals)
 
 ```vue
 <script setup>

--- a/packages/ui-asciinema/README.md
+++ b/packages/ui-asciinema/README.md
@@ -15,19 +15,19 @@ Wrapper of `asciinema-player` for VitePress documentation sites.
 > If you are using VitePress, you will need to add the following configurations to your `vite.config.ts` file like this:
 >
 > ```typescript
-> export default defineConfig(() => {
->   return {
+> // vite.config.ts
+> export default defineConfig({
+>   vite: {
 >     ssr: {
 >       noExternal: [
->         // Add this line to your vite.config.ts
->         '@nolebase/ui-asciinema',
+>         "@nolebase/ui-asciinema",
 >       ],
 >     },
->   }
+>   },
 > })
 > ```
->
-> For more information about why configure this, please refer to the [Server-Side Rendering | Vite](https://vitejs.dev/guide/ssr.html#ssr-externals) documentation.
+
+[^1]: Vite's `ssr.noExternal` config docs: https://vitejs.dev/guide/ssr.html#ssr-externals.
 
 ## Install
 

--- a/packages/ui-asciinema/README.md
+++ b/packages/ui-asciinema/README.md
@@ -10,9 +10,7 @@ Wrapper of `asciinema-player` for VitePress documentation sites.
 
 > [!IMPORTANT]
 >
-> ## For users who imported VitePress related components
->
-> If you are using VitePress, you will need to add the following configurations to your `vite.config.ts` file like this:
+> You will need to add the package to Vite's `ssr.noExternal` config [^1]. Without it your site may not build.
 >
 > ```typescript
 > // vite.config.ts
@@ -51,4 +49,4 @@ pnpm add @nolebase/ui-asciinema -D
 
 ## Documentation
 
-Please refer to [Asciinema Player](https://nolebase-integrations.ayaka.io/pages/en/ui/asciinema-player/) for more information.
+Please refer to [Asciinema Player package's documentation site](https://nolebase-integrations.ayaka.io/pages/en/ui/asciinema-player/) for more information.


### PR DESCRIPTION
- VitePress convention is to configure Vite in the VitePress config file (ref: https://vitepress.dev/reference/site-config#vite). Updates the docs' code samples to follow that convention.
- Even after reading the linked Vite SSR docs, I didn't understand why the package needed to be made noExternal… until I tried building my VitePress site, and the build failed. Updates the ssr.noExternal docs to clarify that.
- Documents how to register a component globally