### PR TITLE
ci: refactor workflows

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  STORE_PATH: ''
-
 jobs:
   build:
     strategy:
@@ -39,28 +36,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          # registry-url required. Learn more at
+          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,15 @@ on:
     branches:
       - main
 
-env:
-  STORE_PATH: ''
-
 jobs:
   unittest:
     strategy:
       matrix:
         node-version: ['20.x', '22.x']
+        os: [ubuntu-latest, windows-latest]
 
     name: Unit Tests - ${{ matrix.node-version }}
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,28 +28,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          # registry-url required. Learn more at
+          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -68,28 +57,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version: 22.x
+          # registry-url required. Learn more at
+          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -105,28 +83,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version: 22.x
+          # registry-url required. Learn more at
+          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/production-docs-deployment.yaml
+++ b/.github/workflows/production-docs-deployment.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - 'main'
 
-env:
-  STORE_PATH: ''
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/production-docs-deployment.yaml
+++ b/.github/workflows/production-docs-deployment.yaml
@@ -21,28 +21,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          # registry-url required. Learn more at
+          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,11 @@ on:
     tags:
       - 'v*'
 
-env:
-  STORE_PATH: ''
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -15,6 +18,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4
@@ -23,24 +31,7 @@ jobs:
           # registry-url required. Learn more at
           # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
           registry-url: 'https://registry.npmjs.org'
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -49,6 +40,12 @@ jobs:
         run: pnpm run packages:build
 
       - name: Packages publish
-        run: pnpm run packages:publish
+        run: pnpm publish -r --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Sync GitHub Release
+        run: pnpx changelogithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "packages:dev": "pnpm cleanup:dist && pnpm -r --filter=./packages/* run dev",
     "packages:stub": "pnpm -r --filter=./packages/* run stub",
     "packages:build": "pnpm cleanup:dist && pnpm -r --filter=./packages/* run build",
-    "packages:publish": "pnpm cleanup:dist && pnpm -r --filter=./packages/* run package:publish",
     "cleanup:dist": "rimraf --glob **/dist",
     "cleanup:node_modules": "rimraf --glob **/node_modules",
     "test": "vitest --coverage",

--- a/packages/markdown-it-bi-directional-links/package.json
+++ b/packages/markdown-it-bi-directional-links/package.json
@@ -41,8 +41,7 @@
   "scripts": {
     "stub": "unbuild --stub",
     "dev": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "markdown-it": ">=14.1.0"

--- a/packages/markdown-it-element-transform/package.json
+++ b/packages/markdown-it-element-transform/package.json
@@ -41,8 +41,8 @@
   "scripts": {
     "stub": "unbuild --stub",
     "dev": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
+
   },
   "peerDependencies": {
     "markdown-it": ">=14.1.0"

--- a/packages/markdown-it-element-transform/package.json
+++ b/packages/markdown-it-element-transform/package.json
@@ -42,7 +42,6 @@
     "stub": "unbuild --stub",
     "dev": "unbuild --stub",
     "build": "unbuild"
-
   },
   "peerDependencies": {
     "markdown-it": ">=14.1.0"

--- a/packages/markdown-it-unlazy-img/package.json
+++ b/packages/markdown-it-unlazy-img/package.json
@@ -44,8 +44,7 @@
   "scripts": {
     "stub": "unbuild --stub",
     "dev": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "markdown-it": ">=14.1.0"

--- a/packages/ui-asciinema/package.json
+++ b/packages/ui-asciinema/package.json
@@ -67,8 +67,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "asciinema-player": "^3.8.1",

--- a/packages/ui-rive-canvas/package.json
+++ b/packages/ui-rive-canvas/package.json
@@ -67,8 +67,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "@rive-app/canvas": "^2.25.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,8 +65,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-breadcrumbs/package.json
+++ b/packages/vitepress-plugin-breadcrumbs/package.json
@@ -49,8 +49,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-enhanced-mark/package.json
+++ b/packages/vitepress-plugin-enhanced-mark/package.json
@@ -38,8 +38,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-enhanced-readabilities/package.json
+++ b/packages/vitepress-plugin-enhanced-readabilities/package.json
@@ -56,8 +56,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-git-changelog/package.json
+++ b/packages/vitepress-plugin-git-changelog/package.json
@@ -67,8 +67,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-highlight-targeted-heading/package.json
+++ b/packages/vitepress-plugin-highlight-targeted-heading/package.json
@@ -51,8 +51,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-index/package.json
+++ b/packages/vitepress-plugin-index/package.json
@@ -59,8 +59,7 @@
   "scripts": {
     "dev": "concurrently \"pnpm run stub\"",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-inline-link-preview/package.json
+++ b/packages/vitepress-plugin-inline-link-preview/package.json
@@ -62,8 +62,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-meta/package.json
+++ b/packages/vitepress-plugin-meta/package.json
@@ -51,8 +51,7 @@
   "scripts": {
     "dev": "concurrently \"pnpm run stub\"",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-og-image/package.json
+++ b/packages/vitepress-plugin-og-image/package.json
@@ -54,8 +54,7 @@
   "scripts": {
     "dev": "concurrently \"pnpm run stub\"",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-page-properties/package.json
+++ b/packages/vitepress-plugin-page-properties/package.json
@@ -61,8 +61,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-sidebar/package.json
+++ b/packages/vitepress-plugin-sidebar/package.json
@@ -44,8 +44,7 @@
   "scripts": {
     "dev": "concurrently \"pnpm run stub\"",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"

--- a/packages/vitepress-plugin-thumbnail-hash/package.json
+++ b/packages/vitepress-plugin-thumbnail-hash/package.json
@@ -58,8 +58,7 @@
   "scripts": {
     "dev": "unbuild --stub",
     "stub": "unbuild --stub",
-    "build": "unbuild",
-    "package:publish": "pnpm build && pnpm publish --access public --no-git-checks"
+    "build": "unbuild"
   },
   "peerDependencies": {
     "vitepress": "catalog:"


### PR DESCRIPTION
- no need to set publish script for each package, `pnpm publish -r` is enough 
- sync github release in ci
- provide PROVENANCE
- use setup-node build-in cache
- run test in linux and windows (ci failed because #388, not this pr intro)

---

BTW, there is a lot of wasted resources in the current CI, such as.

- push: build packages 2 times
- pr: build packages 3 times
- release (with push): build packages 3 times

However, there seems to be no better solution at the moment.
