### PR TITLE
fix(og-image): sep win Windows breaks test

### DIFF
--- a/packages/vitepress-plugin-og-image/src/vitepress/options.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/options.ts
@@ -1,6 +1,6 @@
 import type { SiteConfig } from 'vitepress'
 import type { BuildEndGenerateOpenGraphImagesOptionsCategory, PageItem } from './types'
-import { dirname, resolve, sep } from 'node:path'
+import { dirname, resolve } from 'node:path'
 
 import { fileURLToPath } from 'node:url'
 import { red, yellow } from 'colorette'

--- a/packages/vitepress-plugin-og-image/src/vitepress/options.ts
+++ b/packages/vitepress-plugin-og-image/src/vitepress/options.ts
@@ -88,7 +88,7 @@ export async function applyCategoryText(pageItem: PageItem, categoryOptions?: Bu
       return
     }
 
-    const dirs = pageItem.sourceFilePath.split(sep)
+    const dirs = pageItem.sourceFilePath.split('/')
     if (dirs.length > level)
       return dirs[level]
 


### PR DESCRIPTION
The path separator for `sourceFilePath` is always `\`, so there is no need to import `sep` from `node:path`.

```json
{
  text: 'Asciinema 播放器',
  link: '/pages/en/ui/asciinema-player/',
  title: 'Asciinema 播放器',
  category: '',
  locale: 'zh-CN',
  frontmatter: { title: 'Asciinema Player', category: 'UI' },
  sourceFilePath: '/pages/en/ui/asciinema-player/index.md',
  normalizedSourceFilePath: '/pages/en/ui/asciinema-player/index.md'
}
{
  text: 'Rive Canvas（懒 Teleport）',
  link: '/pages/zh-CN/ui/lazy-teleport-rive-canvas/',
  title: 'Rive Canvas（懒 Teleport）',
  category: '',
  locale: 'zh-CN',
  frontmatter: { title: 'Rive Canvas（懒 Teleport）', category: 'UI' },
  sourceFilePath: '/pages/zh-CN/ui/lazy-teleport-rive-canvas/index.md',
  normalizedSourceFilePath: '/pages/zh-CN/ui/lazy-teleport-rive-canvas/index.md'
}
```