### PR TITLE
fix: two `@default` typo in types.ts (#455)

### DIFF
--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/types.ts
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/types.ts
@@ -311,7 +311,7 @@ export interface Options {
       /**
        * Default percentage of content layout max width
        *
-       * @default 100 (100%)
+       * @default 80 (80%)
        */
       defaultMaxWidth?: number
       /**
@@ -332,7 +332,7 @@ export interface Options {
       /**
        * Default percentage of page layout max width
        *
-       * @default 800 (80%)
+       * @default 100 (100%)
        */
       defaultMaxWidth?: number
       /**


### PR DESCRIPTION
fix: types.ts 两处 `@default` 默认值错误

related issue: #455