### PR TITLE
chore: use org renovate config and override schedule to weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticPrefixFixDepsChoreOthers",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone",
-    ":ignoreModulesAndTests",
-    "group:monorepos",
-    "group:recommended",
-    "group:allNonMajor",
-    "replacements:all",
-    "workarounds:all"
-  ],
-  "rangeStrategy": "bump",
-  "labels": ["dependencies"]
+  "extends": ["local>nolebase/renovate-config", "schedule:weekly"]
 }


### PR DESCRIPTION
在组织级别管理 renovate 配置，以便统一更新。

此外，我们实无必要如此频繁的更新依赖项，这会打扰 watcher，我认为每周或每月是一个合适的选择。

目前的配置中，默认每月更新，在 intergrations 等有必要频繁更新的仓库中，我们覆盖更新计划为每周。

此外，对非 major 更新，如果能通过 build、test 等 ci，则自动合并。

你觉得怎么样？