### PR TITLE
feat: improve ancestor element finding logic in SpotlightHoverBlock

### DIFF
--- a/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightHoverBlock.vue
+++ b/packages/vitepress-plugin-enhanced-readabilities/src/client/components/SpotlightHoverBlock.vue
@@ -50,13 +50,24 @@ function computeBoxStyles(bounding: {
   }
 }
 
-function findChildElementUnderVPDocElement(element: HTMLElement | null) {
-  if (element === null)
-    return null
+function findChildElementUnderVPDocElement(element: HTMLElement | null): HTMLElement | null {
+  const rootContainer = document.querySelector<HTMLElement>('.VPDoc main .vp-doc > div')
+  const allowedContainerTags = ['DIV', 'BLOCKQUOTE', 'UL', 'OL', 'LI']
 
-  if (element.parentElement === document.querySelector('.VPDoc main .vp-doc > div'))
-    return element
-  else return findChildElementUnderVPDocElement(element.parentElement)
+  function findValidAncestor(currentElement: HTMLElement | null): HTMLElement | null {
+    if (!currentElement || !rootContainer || currentElement === rootContainer) return null
+
+    const parent = currentElement.parentElement
+
+    if (!parent) return null
+    if (parent === rootContainer) return currentElement
+    if (!allowedContainerTags.includes(parent.tagName)) return findValidAncestor(parent)
+    if (parent.tagName === 'LI' && currentElement === parent.firstElementChild) return findValidAncestor(parent)
+
+    return findValidAncestor(parent) ? currentElement : null
+  }
+
+  return findValidAncestor(element)
 }
 
 function watchHandler() {


### PR DESCRIPTION
Before:

<img width="738" height="576" alt="image" src="https://github.com/user-attachments/assets/8e9f5d3b-890c-4d50-95f5-b9c8e6c9a1a8" />

After:

<img width="738" height="576" alt="image" src="https://github.com/user-attachments/assets/48dd09a1-e8d5-42f0-a34c-57948aae3eea" />
