### PR TITLE
fix(git-changelog): declare vite peer dependency

### DIFF
--- a/packages/vitepress-plugin-git-changelog/package.json
+++ b/packages/vitepress-plugin-git-changelog/package.json
@@ -76,6 +76,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "peerDependencies": {
+    "vite": "catalog:",
     "vitepress": "catalog:vitepress-all"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,6 +752,9 @@ importers:
       uncrypto:
         specifier: 'catalog:'
         version: 0.1.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(tsx@4.19.2)(yaml@2.8.3)
       vitepress:
         specifier: catalog:vitepress-all
         version: 2.0.0-alpha.17(@types/node@25.6.0)(change-case@5.4.4)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(postcss@8.5.10)(tsx@4.19.2)(typescript@6.0.2)(yaml@2.8.3)


### PR DESCRIPTION
Fixes #617.

The git changelog package imports Vite from its published Vite entrypoint, including runtime `normalizePath` from `vite`. With VitePress 2 alpha, consumers can hit `Cannot find package 'vite'` when the plugin is installed without an explicit Vite dependency in the consuming project.

This adds `vite` as a peer dependency using the existing catalog version and syncs the lockfile importer entry.

Verification:
- Confirmed `packages/vitepress-plugin-git-changelog/src/vite/git.ts` imports runtime `normalizePath` from `vite`.
- Confirmed package metadata now declares `peerDependencies.vite` alongside `vitepress`.
- `pnpm install --lockfile-only --offline` could not complete in my partial API checkout because the trimmed workspace did not include `@nolebase/ui`; no source or generated files were changed beyond package metadata/lock importer sync.